### PR TITLE
Add breakspace to action description to prevent overflows

### DIFF
--- a/components/buttons/button-51.tsx
+++ b/components/buttons/button-51.tsx
@@ -8,7 +8,7 @@ export default function Button51() {
     <Button className="group h-auto gap-4 py-3 text-left" variant="outline">
       <div className="space-y-1">
         <h3>Talent Agency</h3>
-        <p className="font-normal text-muted-foreground">Matches for your roster</p>
+        <p className="text-muted-foreground whitespace-break-spaces font-normal">Matches for your roster</p>
       </div>
       <ChevronRight
         className="opacity-60 transition-transform group-hover:translate-x-0.5"


### PR DESCRIPTION
PS: Maybe it would be a great idea to require having tailwind extension to ensure className orders are consistant ?