### PR TITLE
Add missing group className

### DIFF
--- a/components/buttons/button-49.tsx
+++ b/components/buttons/button-49.tsx
@@ -35,7 +35,7 @@ export default function Button49() {
   }, []);
 
   return (
-    <div>
+    <div className="group">
       <div className="relative inline-flex">
         <Button
           variant="outline"


### PR DESCRIPTION
Filename preview has a group logic.
```
lg:opacity-0 lg:group-focus-within/item:opacity-100 lg:group-hover/item:opacity-100
```

But as no group className was present, fileName was not showing.

I think this was the attended comportment... even if i don't understand the purpose of not showing filename on larger screens.