### PR TITLE
fix: adjust border radius for select inputs for safari

### DIFF
--- a/components/inputs/input-17.tsx
+++ b/components/inputs/input-17.tsx
@@ -11,7 +11,7 @@ export default function Input17() {
       <div className="flex rounded-lg shadow-sm shadow-black/[.04]">
         <div className="relative">
           <select
-            className="peer inline-flex h-full appearance-none items-center rounded-s-lg border border-input bg-background pe-8 ps-3 text-sm text-muted-foreground ring-offset-background transition-shadow hover:bg-accent hover:text-foreground focus:z-10 focus-visible:border-ring focus-visible:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/30 focus-visible:ring-offset-2 disabled:pointer-events-none disabled:cursor-not-allowed disabled:opacity-50"
+            className="peer inline-flex h-full appearance-none items-center rounded-none rounded-s-lg border border-input bg-background pe-8 ps-3 text-sm text-muted-foreground ring-offset-background transition-shadow hover:bg-accent hover:text-foreground focus:z-10 focus-visible:border-ring focus-visible:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/30 focus-visible:ring-offset-2 disabled:pointer-events-none disabled:cursor-not-allowed disabled:opacity-50"
             aria-label="Protocol"
           >
             <option value="https://">https://</option>

--- a/components/inputs/input-18.tsx
+++ b/components/inputs/input-18.tsx
@@ -17,7 +17,7 @@ export default function Input18() {
         />
         <div className="relative">
           <select
-            className="peer inline-flex h-full appearance-none items-center rounded-e-lg border border-input bg-background pe-8 ps-3 text-sm text-muted-foreground ring-offset-background transition-shadow hover:bg-accent hover:text-foreground focus:z-10 focus-visible:border-ring focus-visible:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/30 focus-visible:ring-offset-2 disabled:pointer-events-none disabled:cursor-not-allowed disabled:opacity-50"
+            className="peer inline-flex h-full appearance-none items-center rounded-none rounded-e-lg border border-input bg-background pe-8 ps-3 text-sm text-muted-foreground ring-offset-background transition-shadow hover:bg-accent hover:text-foreground focus:z-10 focus-visible:border-ring focus-visible:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/30 focus-visible:ring-offset-2 disabled:pointer-events-none disabled:cursor-not-allowed disabled:opacity-50"
             aria-label="Domain suffix"
           >
             <option>.com</option>


### PR DESCRIPTION
Looks like safari needs a resert for border-radius

![shot2024-11-07 at 10 52 19@2x](https://github.com/user-attachments/assets/d7aa6e19-8d51-42b4-8b42-c1d332d433e9)

![shot2024-11-07 at 10 57 26@2x](https://github.com/user-attachments/assets/b229b942-69df-43bd-8ccd-2130a87e2a1e)

BTW: Thank you very much for all the work 👏