### PR TITLE
Added Theme Toggler and Loading Button with Tooltip

### DIFF
--- a/app/buttons/page.tsx
+++ b/app/buttons/page.tsx
@@ -62,6 +62,8 @@ const files = [
   "button-49",
   "button-50",
   "button-51",
+  "button-52",
+  "button-53",
 ];
 
 export default function Page() {

--- a/components/buttons/button-52.tsx
+++ b/components/buttons/button-52.tsx
@@ -1,0 +1,20 @@
+"use client";
+import { Button } from "@/components/ui/button";
+import { Loader2 } from "lucide-react";
+import { useState } from "react";
+
+export default function Button52() {
+  const [isLoading, setIsLoading] = useState(false);
+  const handleLoading = async () => {
+    setIsLoading(true);
+    await new Promise((resolve) => setTimeout(resolve, 2000)); // Simulating API call
+    setIsLoading(false);
+    console.log("Action Completed");
+  };
+  return (
+    <Button onClick={handleLoading} disabled={isLoading}>
+      {isLoading && <Loader2 size={20} className="mr-2 animate-spin" />}
+      Submit
+    </Button>
+  );
+}

--- a/components/buttons/button-53.tsx
+++ b/components/buttons/button-53.tsx
@@ -1,0 +1,28 @@
+"use client";
+import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from "@/components/ui/tooltip";
+import { Moon, Sun } from "lucide-react";
+import { useState } from "react";
+import { Button } from "../ui/button";
+
+export default function Button52() {
+  const [isDark, setIsDark] = useState(false);
+
+  const toggleTheme = () => {
+    setIsDark((prev) => !prev);
+  };
+
+  return (
+    <TooltipProvider delayDuration={0}>
+      <Tooltip>
+        <TooltipTrigger asChild>
+          <Button onClick={toggleTheme} variant="outline" size="icon">
+            {isDark ? <Moon /> : <Sun />}
+          </Button>
+        </TooltipTrigger>
+        <TooltipContent>
+          <p>{isDark ? "Dark mode" : "Light mode"}</p>
+        </TooltipContent>
+      </Tooltip>
+    </TooltipProvider>
+  );
+}


### PR DESCRIPTION
This pull request introduces two new buttons with the following functionalities:

1. Theme Toggler Button:

Toggles between light/dark mode icons.
Includes a tooltip for better user experience.
Currently, it only changes the icon, not the theme itself. Theme switching functionality can be added in future updates.
Loading Button:

2. Displays a loading spinner when clicked.
The loading spinner disappears automatically after 2 seconds.
Provides interactive feedback to the user during loading actions.