### PR TITLE
fix /sliders link hover style

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -101,7 +101,7 @@ export default function Page() {
                   <li>
                     <Link
                       href="/sliders"
-                      className="inline-flex w-full items-center justify-between whitespace-nowrap rounded-lg border border-border bg-background p-4 font-bold shadow-sm shadow-black/[0.04] sm:h-14"
+                      className="inline-flex w-full items-center justify-between whitespace-nowrap rounded-lg border border-border bg-background p-4 font-bold shadow-sm shadow-black/5 ring-offset-background transition-colors hover:bg-accent hover:text-accent-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/70 focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50 sm:h-14"
                     >
                       <span className="truncate">Sliders</span>
                       <ArrowRight


### PR DESCRIPTION
Adds hover state styling to match the other links.

Before:
<img width="785" alt="image" src="https://github.com/user-attachments/assets/e3cbffe2-922c-45fa-9d7e-0e5b4116c703">

After:
<img width="785" alt="image" src="https://github.com/user-attachments/assets/85e4d680-33be-44eb-a718-2a737422b9f2">
