### PR TITLE
fix: correct yarn command syntax in CLI commands

### DIFF
--- a/components/cli-commands.tsx
+++ b/components/cli-commands.tsx
@@ -11,7 +11,7 @@ export default function CliCommands({ name }: { name: string }) {
   const commands = {
     pnpm: `pnpm dlx shadcn@latest add https://originui.com/r/${name}.json`,
     npm: `npx shadcn@latest add https://originui.com/r/${name}.json`,
-    yarn: `npx dlx shadcn@latest add https://originui.com/r/${name}.json`,
+    yarn: `npx shadcn@latest add https://originui.com/r/${name}.json`,
     bun: `bunx --bun shadcn@latest add https://originui.com/r/${name}.json`,
   };
 


### PR DESCRIPTION
This PR resolves an issue with the yarn CLI command used for installing components. The previous implementation had incorrect syntax, which has now been fixed.

File Updated:
[cli-commands.tsx](https://github.com/origin-space/originui/blob/main/components/cli-commands.tsx)