### PR TITLE
remove `/flags` from `comp-46` dependency

### DIFF
--- a/public/r/comp-46.json
+++ b/public/r/comp-46.json
@@ -4,7 +4,6 @@
   "type": "registry:component",
   "dependencies": [
     "react-phone-number-input",
-    "react-phone-number-input/flags"
   ],
   "registryDependencies": [
     "https://originui.com/r/input.json",


### PR DESCRIPTION
Fixes #253

```diff
"dependencies": [
    "react-phone-number-input",
-    "react-phone-number-input/flags"
],
```