### PR TITLE
Added system theme option to the theme toggle

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -40,14 +40,9 @@ export default function RootLayout({
   return (
     <html lang="en" suppressHydrationWarning>
       <body
-        className={`${fontSans.variable} ${fontHeading.variable} font-sans antialiased has-not-data-home:before:absolute has-not-data-home:before:inset-x-0 has-not-data-home:before:h-100 has-not-data-home:before:bg-linear-to-b has-not-data-home:before:from-zinc-100 has-data-home:bg-zinc-50 dark:has-not-data-home:before:hidden dark:has-data-home:bg-zinc-950`}
+        className={`${fontSans.variable} ${fontHeading.variable} font-sans antialiased transition-colors duration-200 ease-in has-not-data-home:before:absolute has-not-data-home:before:inset-x-0 has-not-data-home:before:h-100 has-not-data-home:before:bg-linear-to-b has-not-data-home:before:from-zinc-100 has-data-home:bg-zinc-50 dark:has-not-data-home:before:hidden dark:has-data-home:bg-zinc-950`}
       >
-        <ThemeProvider
-          attribute="class"
-          defaultTheme="system"
-          enableSystem
-          disableTransitionOnChange
-        >
+        <ThemeProvider attribute="class" defaultTheme="system" enableSystem>
           <div className="overflow-hidden px-4 supports-[overflow:clip]:overflow-clip sm:px-6">
             <div className="before:bg-[linear-gradient(to_bottom,--theme(--color-border/.3),--theme(--color-border)_200px,--theme(--color-border)_calc(100%-200px),--theme(--color-border/.3))] after:bg-[linear-gradient(to_bottom,--theme(--color-border/.3),--theme(--color-border)_200px,--theme(--color-border)_calc(100%-200px),--theme(--color-border/.3))] relative mx-auto w-full max-w-6xl before:absolute before:inset-y-0 before:-left-12 before:w-px after:absolute after:inset-y-0 after:-right-12 after:w-px">
               <div className="relative flex min-h-screen flex-col">

--- a/components/header.tsx
+++ b/components/header.tsx
@@ -19,13 +19,21 @@ export default function Header() {
           className="outline-ring/30 dark:outline-ring/40 rounded-full outline-offset-2 focus-visible:outline-2"
         >
           <span className="sr-only">Origin UI</span>
-          <Image src={Logo} alt="Origin UI logo" width={117} height={24} className="dark:hidden" />
+          <Image
+            src={Logo}
+            alt="Origin UI logo"
+            width={117}
+            height={24}
+            className="dark:hidden"
+            priority={true}
+          />
           <Image
             src={LogoDark}
             alt="Origin UI logo"
             width={117}
             height={24}
             className="hidden dark:block"
+            priority={true}
           />
         </Link>
         <div className="flex items-center gap-4 sm:gap-8">

--- a/components/theme-toggle.tsx
+++ b/components/theme-toggle.tsx
@@ -1,33 +1,61 @@
 "use client";
 
-import { RiMoonClearLine, RiSunLine } from "@remixicon/react";
+import { Toggle } from "@/registry/default/ui/toggle";
+import { cx } from "class-variance-authority";
+import { MoonIcon, SunIcon, SunMoon } from "lucide-react";
 import { useTheme } from "next-themes";
-import { useId } from "react";
+import { useEffect, useState } from "react";
+
+const classes = {
+  base: "absolute shrink-0 transition-all duration-200",
+  visible: "scale-100 opacity-100",
+  hidden: "scale-0 opacity-0",
+};
 
 export default function ThemeToggle() {
-  const id = useId();
+  const [isClient, setIsClient] = useState(false);
+
+  useEffect(() => {
+    setIsClient(true);
+  }, []);
+
   const { theme, setTheme } = useTheme();
 
+  const changeTheme = () => {
+    setTheme((current) => {
+      if (current === "light") return "dark";
+      if (current === "dark") return "system";
+      return "light";
+    });
+  };
+
   return (
-    <div className="flex flex-col justify-center">
-      <input
-        type="checkbox"
-        name="theme-toggle"
-        id={id}
-        className="peer sr-only"
-        checked={theme === "dark"}
-        onChange={() => setTheme(theme === "dark" ? "light" : "dark")}
-        aria-label="Toggle dark mode"
-      />
-      <label
-        className="text-muted-foreground outline-ring/30 dark:outline-ring/40 relative inline-flex size-9 cursor-pointer items-center justify-center rounded-full transition-colors peer-focus-visible:outline-2"
-        htmlFor={id}
-        aria-hidden="true"
-      >
-        <RiSunLine className="dark:hidden" size={20} aria-hidden="true" />
-        <RiMoonClearLine className="hidden dark:block" size={20} aria-hidden="true" />
-        <span className="sr-only">Switch to light / dark version</span>
-      </label>
-    </div>
+    <Toggle
+      variant="outline"
+      className="group size-9"
+      onPressedChange={changeTheme}
+      pressed={false}
+      aria-label="Toggle theme (default system)"
+    >
+      {isClient && (
+        <>
+          <SunMoon
+            size={18}
+            className={cx(classes.base, theme === "system" ? classes.visible : classes.hidden)}
+            aria-hidden="true"
+          />
+          <SunIcon
+            size={18}
+            className={cx(classes.base, theme === "light" ? classes.visible : classes.hidden)}
+            aria-hidden="true"
+          />
+          <MoonIcon
+            size={18}
+            className={cx(classes.base, theme === "dark" ? classes.visible : classes.hidden)}
+            aria-hidden="true"
+          />
+        </>
+      )}
+    </Toggle>
   );
 }

--- a/components/theme-toggle.tsx
+++ b/components/theme-toggle.tsx
@@ -32,12 +32,12 @@ export default function ThemeToggle() {
   return (
     <Toggle
       variant="outline"
-      className="group size-9"
+      className="group size-9 p-0"
       onPressedChange={changeTheme}
       pressed={false}
       aria-label="Toggle theme (default system)"
     >
-      {isClient && (
+      {isClient ? (
         <>
           <SunMoon
             size={18}
@@ -55,6 +55,8 @@ export default function ThemeToggle() {
             aria-hidden="true"
           />
         </>
+      ) : (
+        <div className="h-[18px] w-[18px] animate-pulse rounded bg-gray-200 dark:bg-gray-700" />
       )}
     </Toggle>
   );


### PR DESCRIPTION
# Context:
We use the `next-themes` library to manage our theme state. One of its many features is recognizing the system theme preferences (using the `prefers-color-scheme` [media query](https://developer.mozilla.org/en-US/docs/Web/CSS/@media/prefers-color-scheme)).

# Current behavior:
By default, the value of the `theme` is "system" and the color scheme follows the system preferences.
However, after switching the color scheme via toggle there is no way to return to the system preference. 

https://github.com/user-attachments/assets/25b91638-9383-40ea-9fe0-10a90c7675d7


# Suggested behavior:
## Third "system default" option:
It is enabled by default and the corresponding icon is shown. The page listens to the system preferences:

https://github.com/user-attachments/assets/8a948f34-6004-4643-b37e-10368fcacddf

We can still choose our own preference, which will persist in the locale storage (actually the `next-themes` writes a value "system" in local storage on the first load as well):

https://github.com/user-attachments/assets/81bca257-1c17-42da-8e3e-d897e4b2a967

## Icon animation
I've also added some animation to the icon.

https://github.com/user-attachments/assets/69156d35-e9df-45c6-b93f-5c995ef89143


# Technical decisions explanation:
## Replaced checkbox with toggle component.
I think this component should be a simple button with a corresponding area label. 
# Future improvements:
- Right implementation for smooth light/dark image opacity change.