### PR TITLE
fix: update cmd's urls to follow repoUrl's order

### DIFF
--- a/app/layouts/page.tsx
+++ b/app/layouts/page.tsx
@@ -17,7 +17,7 @@ const cards = [
     demoUrl: "https://crafted.is/exp6",
     repoUrl:
       "https://github.com/origin-space/ui-experiments/tree/main/apps/experiment-06",
-    cmd: "npx shadcn@canary init https://ui-experiments-green.vercel.app/r/experiment-01.json",
+    cmd: "npx shadcn@canary init https://ui-experiment-06.vercel.app/r/experiment-06.json",
     imgHeight: 688,
   },
   {
@@ -26,7 +26,7 @@ const cards = [
     demoUrl: "https://crafted.is/exp5",
     repoUrl:
       "https://github.com/origin-space/ui-experiments/tree/main/apps/experiment-05",
-    cmd: "npx shadcn@canary init https://ui-experiment-02.vercel.app/r/experiment-02.json",
+    cmd: "npx shadcn@canary init https://ui-experiment-05.vercel.app/r/experiment-05.json",
     imgHeight: 770,
   },
   {
@@ -35,7 +35,7 @@ const cards = [
     demoUrl: "https://crafted.is/exp4",
     repoUrl:
       "https://github.com/origin-space/ui-experiments/tree/main/apps/experiment-04",
-    cmd: "npx shadcn@canary init https://ui-experiment-03.vercel.app/r/experiment-03.json",
+    cmd: "npx shadcn@canary init https://ui-experiment-04.vercel.app/r/experiment-04.json",
     imgHeight: 894,
   },
   {
@@ -44,7 +44,7 @@ const cards = [
     demoUrl: "https://crafted.is/exp3",
     repoUrl:
       "https://github.com/origin-space/ui-experiments/tree/main/apps/experiment-03",
-    cmd: "npx shadcn@canary init https://ui-experiment-04.vercel.app/r/experiment-04.json",
+    cmd: "npx shadcn@canary init https://ui-experiment-03.vercel.app/r/experiment-03.json",
     imgHeight: 829,
   },
   {
@@ -53,7 +53,7 @@ const cards = [
     demoUrl: "https://crafted.is/exp2",
     repoUrl:
       "https://github.com/origin-space/ui-experiments/tree/main/apps/experiment-02",
-    cmd: "npx shadcn@canary init https://ui-experiment-05.vercel.app/r/experiment-05.json",
+    cmd: "npx shadcn@canary init https://ui-experiment-02.vercel.app/r/experiment-02.json",
     imgHeight: 700,
   },
   {
@@ -62,7 +62,7 @@ const cards = [
     demoUrl: "https://crafted.is/exp1",
     repoUrl:
       "https://github.com/origin-space/ui-experiments/tree/main/apps/experiment-01",
-    cmd: "npx shadcn@canary init https://ui-experiment-06.vercel.app/r/experiment-06.json",
+    cmd: "npx shadcn@canary init https://ui-experiments-green.vercel.app/r/experiment-01.json",
     imgHeight: 894,
   },
 ]


### PR DESCRIPTION

The PR updates the command URLs to match their corresponding repository URLs. Here's a table showing the changes:

| ID | Title | Old Command URL | New Command URL |
|----|-------|----------------|----------------|
| 6 | Event Calendar | experiment-01.json | experiment-06.json |
| 5 | Candlestick Chart | experiment-02.json | experiment-05.json |
| 4 | Crypto Wallet | experiment-03.json | experiment-04.json |
| 3 | SaaS Dashboard | experiment-04.json | experiment-03.json |
| 2 | AI Chat | experiment-05.json | experiment-02.json |
| 1 | Dark Table | experiment-06.json | experiment-01.json |

