### PR TITLE
fix: change highlighted code from ts to tsx for proper syntax highlight

### DIFF
--- a/components/component-details.tsx
+++ b/components/component-details.tsx
@@ -60,7 +60,7 @@ export default function ComponentDetails({
         setCode(codeContent)
 
         // Pre-highlight the code
-        const highlighted = await highlight(codeContent, "ts")
+        const highlighted = await highlight(codeContent, "tsx")
         setHighlightedCode(highlighted)
       } catch (error) {
         console.error("Failed to load code:", error)
@@ -126,7 +126,7 @@ export default function ComponentDetails({
                   <>
                     <CodeBlock
                       code={code}
-                      lang="ts"
+                      lang="tsx"
                       preHighlighted={highlightedCode}
                     />
                     <CopyButton componentSource={code} />


### PR DESCRIPTION
Minor fix, but fixes the code syntax highlight in `CodeBlock` component.

Before:
![Screenshot 2025-04-25 at 17 23 25](https://github.com/user-attachments/assets/2f924567-8ad1-4f65-b197-47e69b2861b2)

After:
![Screenshot 2025-04-25 at 17 22 50](https://github.com/user-attachments/assets/17f86542-cfea-4f89-a5a6-0785e5ae8cfb)
