### PR TITLE
fix(broken): infallible registry generation, 0 error possible

### DIFF
--- a/package.json
+++ b/package.json
@@ -92,6 +92,7 @@
     "typescript": "^5.8.2"
   },
   "prettier": {
+    "printWidth": 100,
     "endOfLine": "lf",
     "semi": false,
     "singleQuote": false,

--- a/package.json
+++ b/package.json
@@ -92,7 +92,6 @@
     "typescript": "^5.8.2"
   },
   "prettier": {
-    "printWidth": 100,
     "endOfLine": "lf",
     "semi": false,
     "singleQuote": false,

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "scripts": {
     "dev": "next dev --turbopack",
     "build": "pnpm format:write && next build",
-    "registry:build": "shadcn build",
+    "registry:build": "npx smart-registry",
     "start": "next start",
     "lint": "next lint",
     "lint:fix": "next lint --fix",

--- a/registry.json
+++ b/registry.json
@@ -116,10 +116,19 @@
     {
       "name": "command",
       "type": "registry:ui",
-      "dependencies": ["cmdk@1.0.0"],
       "files": [
         {
           "path": "registry/default/ui/command.tsx",
+          "type": "registry:ui"
+        }
+      ]
+    },
+    {
+      "name": "cropper",
+      "type": "registry:ui",
+      "files": [
+        {
+          "path": "registry/default/ui/cropper.tsx",
           "type": "registry:ui"
         }
       ]
@@ -454,7 +463,10 @@
         }
       ],
       "meta": {
-        "tags": ["input", "label"]
+        "tags": [
+          "input",
+          "label"
+        ]
       }
     },
     {
@@ -467,7 +479,11 @@
         }
       ],
       "meta": {
-        "tags": ["input", "label", "required"]
+        "tags": [
+          "input",
+          "label",
+          "required"
+        ]
       }
     },
     {
@@ -480,7 +496,11 @@
         }
       ],
       "meta": {
-        "tags": ["input", "label", "helper"]
+        "tags": [
+          "input",
+          "label",
+          "helper"
+        ]
       }
     },
     {
@@ -493,7 +513,11 @@
         }
       ],
       "meta": {
-        "tags": ["input", "label", "hint"]
+        "tags": [
+          "input",
+          "label",
+          "hint"
+        ]
       }
     },
     {
@@ -506,7 +530,10 @@
         }
       ],
       "meta": {
-        "tags": ["input", "label"]
+        "tags": [
+          "input",
+          "label"
+        ]
       }
     },
     {
@@ -519,7 +546,11 @@
         }
       ],
       "meta": {
-        "tags": ["input", "label", "error"]
+        "tags": [
+          "input",
+          "label",
+          "error"
+        ]
       }
     },
     {
@@ -532,7 +563,10 @@
         }
       ],
       "meta": {
-        "tags": ["input", "label"]
+        "tags": [
+          "input",
+          "label"
+        ]
       }
     },
     {
@@ -545,7 +579,11 @@
         }
       ],
       "meta": {
-        "tags": ["input", "label", "disabled"]
+        "tags": [
+          "input",
+          "label",
+          "disabled"
+        ]
       }
     },
     {
@@ -558,7 +596,10 @@
         }
       ],
       "meta": {
-        "tags": ["input", "label"]
+        "tags": [
+          "input",
+          "label"
+        ]
       }
     },
     {
@@ -571,7 +612,10 @@
         }
       ],
       "meta": {
-        "tags": ["input", "label"]
+        "tags": [
+          "input",
+          "label"
+        ]
       }
     },
     {
@@ -584,7 +628,10 @@
         }
       ],
       "meta": {
-        "tags": ["input", "label"]
+        "tags": [
+          "input",
+          "label"
+        ]
       }
     },
     {
@@ -597,7 +644,10 @@
         }
       ],
       "meta": {
-        "tags": ["input", "label"]
+        "tags": [
+          "input",
+          "label"
+        ]
       }
     },
     {
@@ -610,7 +660,10 @@
         }
       ],
       "meta": {
-        "tags": ["input", "label"]
+        "tags": [
+          "input",
+          "label"
+        ]
       }
     },
     {
@@ -623,7 +676,10 @@
         }
       ],
       "meta": {
-        "tags": ["input", "label"]
+        "tags": [
+          "input",
+          "label"
+        ]
       }
     },
     {
@@ -636,7 +692,10 @@
         }
       ],
       "meta": {
-        "tags": ["input", "label"]
+        "tags": [
+          "input",
+          "label"
+        ]
       }
     },
     {
@@ -649,7 +708,10 @@
         }
       ],
       "meta": {
-        "tags": ["input", "label"]
+        "tags": [
+          "input",
+          "label"
+        ]
       }
     },
     {
@@ -662,7 +724,12 @@
         }
       ],
       "meta": {
-        "tags": ["input", "label", "select", "native select"]
+        "tags": [
+          "input",
+          "label",
+          "select",
+          "native select"
+        ]
       }
     },
     {
@@ -675,7 +742,12 @@
         }
       ],
       "meta": {
-        "tags": ["input", "label", "select", "native select"]
+        "tags": [
+          "input",
+          "label",
+          "select",
+          "native select"
+        ]
       }
     },
     {
@@ -688,7 +760,11 @@
         }
       ],
       "meta": {
-        "tags": ["input", "label", "button"]
+        "tags": [
+          "input",
+          "label",
+          "button"
+        ]
       }
     },
     {
@@ -701,7 +777,11 @@
         }
       ],
       "meta": {
-        "tags": ["input", "label", "button"]
+        "tags": [
+          "input",
+          "label",
+          "button"
+        ]
       }
     },
     {
@@ -714,7 +794,11 @@
         }
       ],
       "meta": {
-        "tags": ["input", "label", "button"]
+        "tags": [
+          "input",
+          "label",
+          "button"
+        ]
       }
     },
     {
@@ -727,7 +811,11 @@
         }
       ],
       "meta": {
-        "tags": ["input", "label", "button"]
+        "tags": [
+          "input",
+          "label",
+          "button"
+        ]
       }
     },
     {
@@ -740,7 +828,12 @@
         }
       ],
       "meta": {
-        "tags": ["input", "label", "button", "password"]
+        "tags": [
+          "input",
+          "label",
+          "button",
+          "password"
+        ]
       }
     },
     {
@@ -753,7 +846,11 @@
         }
       ],
       "meta": {
-        "tags": ["input", "label", "button"]
+        "tags": [
+          "input",
+          "label",
+          "button"
+        ]
       }
     },
     {
@@ -766,7 +863,12 @@
         }
       ],
       "meta": {
-        "tags": ["input", "label", "search", "kbd"]
+        "tags": [
+          "input",
+          "label",
+          "search",
+          "kbd"
+        ]
       }
     },
     {
@@ -779,7 +881,12 @@
         }
       ],
       "meta": {
-        "tags": ["input", "label", "button", "search"]
+        "tags": [
+          "input",
+          "label",
+          "button",
+          "search"
+        ]
       }
     },
     {
@@ -792,7 +899,12 @@
         }
       ],
       "meta": {
-        "tags": ["input", "label", "button", "search"]
+        "tags": [
+          "input",
+          "label",
+          "button",
+          "search"
+        ]
       }
     },
     {
@@ -805,7 +917,13 @@
         }
       ],
       "meta": {
-        "tags": ["input", "label", "button", "number", "react aria"]
+        "tags": [
+          "input",
+          "label",
+          "button",
+          "number",
+          "react aria"
+        ]
       }
     },
     {
@@ -818,7 +936,13 @@
         }
       ],
       "meta": {
-        "tags": ["input", "label", "button", "number", "react aria"]
+        "tags": [
+          "input",
+          "label",
+          "button",
+          "number",
+          "react aria"
+        ]
       }
     },
     {
@@ -831,7 +955,11 @@
         }
       ],
       "meta": {
-        "tags": ["input", "label", "file"]
+        "tags": [
+          "input",
+          "label",
+          "file"
+        ]
       }
     },
     {
@@ -844,7 +972,10 @@
         }
       ],
       "meta": {
-        "tags": ["input", "label"]
+        "tags": [
+          "input",
+          "label"
+        ]
       }
     },
     {
@@ -857,7 +988,10 @@
         }
       ],
       "meta": {
-        "tags": ["input", "label"]
+        "tags": [
+          "input",
+          "label"
+        ]
       }
     },
     {
@@ -870,7 +1004,10 @@
         }
       ],
       "meta": {
-        "tags": ["input", "label"]
+        "tags": [
+          "input",
+          "label"
+        ]
       }
     },
     {
@@ -883,7 +1020,10 @@
         }
       ],
       "meta": {
-        "tags": ["input", "label"]
+        "tags": [
+          "input",
+          "label"
+        ]
       }
     },
     {
@@ -896,7 +1036,10 @@
         }
       ],
       "meta": {
-        "tags": ["input", "label"]
+        "tags": [
+          "input",
+          "label"
+        ]
       }
     },
     {
@@ -909,7 +1052,12 @@
         }
       ],
       "meta": {
-        "tags": ["input", "label", "date", "react aria"]
+        "tags": [
+          "input",
+          "label",
+          "date",
+          "react aria"
+        ]
       }
     },
     {
@@ -922,7 +1070,12 @@
         }
       ],
       "meta": {
-        "tags": ["input", "label", "date", "react aria"]
+        "tags": [
+          "input",
+          "label",
+          "date",
+          "react aria"
+        ]
       }
     },
     {
@@ -935,7 +1088,12 @@
         }
       ],
       "meta": {
-        "tags": ["input", "label", "date", "react aria"]
+        "tags": [
+          "input",
+          "label",
+          "date",
+          "react aria"
+        ]
       }
     },
     {
@@ -948,7 +1106,12 @@
         }
       ],
       "meta": {
-        "tags": ["input", "label", "date", "react aria"]
+        "tags": [
+          "input",
+          "label",
+          "date",
+          "react aria"
+        ]
       }
     },
     {
@@ -961,7 +1124,12 @@
         }
       ],
       "meta": {
-        "tags": ["input", "label", "date", "react aria"]
+        "tags": [
+          "input",
+          "label",
+          "date",
+          "react aria"
+        ]
       }
     },
     {
@@ -974,7 +1142,14 @@
         }
       ],
       "meta": {
-        "tags": ["input", "label", "date", "calendar", "picker", "react aria"]
+        "tags": [
+          "input",
+          "label",
+          "date",
+          "calendar",
+          "picker",
+          "react aria"
+        ]
       }
     },
     {
@@ -987,7 +1162,15 @@
         }
       ],
       "meta": {
-        "tags": ["input", "label", "date", "calendar", "range calendar", "picker", "react aria"]
+        "tags": [
+          "input",
+          "label",
+          "date",
+          "calendar",
+          "range calendar",
+          "picker",
+          "react aria"
+        ]
       }
     },
     {
@@ -1000,7 +1183,15 @@
         }
       ],
       "meta": {
-        "tags": ["input", "label", "date", "calendar", "range calendar", "picker", "react aria"]
+        "tags": [
+          "input",
+          "label",
+          "date",
+          "calendar",
+          "range calendar",
+          "picker",
+          "react aria"
+        ]
       }
     },
     {
@@ -1013,7 +1204,11 @@
         }
       ],
       "meta": {
-        "tags": ["input", "label", "otp"]
+        "tags": [
+          "input",
+          "label",
+          "otp"
+        ]
       }
     },
     {
@@ -1026,7 +1221,11 @@
         }
       ],
       "meta": {
-        "tags": ["input", "label", "otp"]
+        "tags": [
+          "input",
+          "label",
+          "otp"
+        ]
       }
     },
     {
@@ -1039,7 +1238,11 @@
         }
       ],
       "meta": {
-        "tags": ["input", "label", "phone"]
+        "tags": [
+          "input",
+          "label",
+          "phone"
+        ]
       }
     },
     {
@@ -1052,7 +1255,14 @@
         }
       ],
       "meta": {
-        "tags": ["input", "label", "checkout", "payment", "credit card", "form"]
+        "tags": [
+          "input",
+          "label",
+          "checkout",
+          "payment",
+          "credit card",
+          "form"
+        ]
       }
     },
     {
@@ -1065,7 +1275,14 @@
         }
       ],
       "meta": {
-        "tags": ["input", "label", "checkout", "payment", "credit card", "form"]
+        "tags": [
+          "input",
+          "label",
+          "checkout",
+          "payment",
+          "credit card",
+          "form"
+        ]
       }
     },
     {
@@ -1078,7 +1295,14 @@
         }
       ],
       "meta": {
-        "tags": ["input", "label", "checkout", "payment", "credit card", "form"]
+        "tags": [
+          "input",
+          "label",
+          "checkout",
+          "payment",
+          "credit card",
+          "form"
+        ]
       }
     },
     {
@@ -1091,7 +1315,14 @@
         }
       ],
       "meta": {
-        "tags": ["input", "label", "checkout", "payment", "credit card", "form"]
+        "tags": [
+          "input",
+          "label",
+          "checkout",
+          "payment",
+          "credit card",
+          "form"
+        ]
       }
     },
     {
@@ -1104,7 +1335,11 @@
         }
       ],
       "meta": {
-        "tags": ["input", "label", "password"]
+        "tags": [
+          "input",
+          "label",
+          "password"
+        ]
       }
     },
     {
@@ -1117,7 +1352,11 @@
         }
       ],
       "meta": {
-        "tags": ["input", "label", "read-only"]
+        "tags": [
+          "input",
+          "label",
+          "read-only"
+        ]
       }
     },
     {
@@ -1130,7 +1369,11 @@
         }
       ],
       "meta": {
-        "tags": ["input", "label", "copy"]
+        "tags": [
+          "input",
+          "label",
+          "copy"
+        ]
       }
     },
     {
@@ -1143,7 +1386,11 @@
         }
       ],
       "meta": {
-        "tags": ["input", "label", "mask"]
+        "tags": [
+          "input",
+          "label",
+          "mask"
+        ]
       }
     },
     {
@@ -1156,7 +1403,12 @@
         }
       ],
       "meta": {
-        "tags": ["input", "label", "mask", "time"]
+        "tags": [
+          "input",
+          "label",
+          "mask",
+          "time"
+        ]
       }
     },
     {
@@ -1169,7 +1421,12 @@
         }
       ],
       "meta": {
-        "tags": ["input", "label", "tag", "emblor"]
+        "tags": [
+          "input",
+          "label",
+          "tag",
+          "emblor"
+        ]
       }
     },
     {
@@ -1182,7 +1439,12 @@
         }
       ],
       "meta": {
-        "tags": ["input", "label", "tag", "emblor"]
+        "tags": [
+          "input",
+          "label",
+          "tag",
+          "emblor"
+        ]
       }
     },
     {
@@ -1195,7 +1457,11 @@
         }
       ],
       "meta": {
-        "tags": ["input", "label", "otp"]
+        "tags": [
+          "input",
+          "label",
+          "otp"
+        ]
       }
     },
     {
@@ -1208,7 +1474,10 @@
         }
       ],
       "meta": {
-        "tags": ["label", "textarea"]
+        "tags": [
+          "label",
+          "textarea"
+        ]
       }
     },
     {
@@ -1221,7 +1490,11 @@
         }
       ],
       "meta": {
-        "tags": ["label", "textarea", "required"]
+        "tags": [
+          "label",
+          "textarea",
+          "required"
+        ]
       }
     },
     {
@@ -1234,7 +1507,11 @@
         }
       ],
       "meta": {
-        "tags": ["label", "textarea", "helper"]
+        "tags": [
+          "label",
+          "textarea",
+          "helper"
+        ]
       }
     },
     {
@@ -1247,7 +1524,11 @@
         }
       ],
       "meta": {
-        "tags": ["label", "textarea", "hint"]
+        "tags": [
+          "label",
+          "textarea",
+          "hint"
+        ]
       }
     },
     {
@@ -1260,7 +1541,10 @@
         }
       ],
       "meta": {
-        "tags": ["label", "textarea"]
+        "tags": [
+          "label",
+          "textarea"
+        ]
       }
     },
     {
@@ -1273,7 +1557,11 @@
         }
       ],
       "meta": {
-        "tags": ["label", "textarea", "error"]
+        "tags": [
+          "label",
+          "textarea",
+          "error"
+        ]
       }
     },
     {
@@ -1286,7 +1574,10 @@
         }
       ],
       "meta": {
-        "tags": ["label", "textarea"]
+        "tags": [
+          "label",
+          "textarea"
+        ]
       }
     },
     {
@@ -1299,7 +1590,10 @@
         }
       ],
       "meta": {
-        "tags": ["label", "textarea"]
+        "tags": [
+          "label",
+          "textarea"
+        ]
       }
     },
     {
@@ -1312,7 +1606,11 @@
         }
       ],
       "meta": {
-        "tags": ["label", "textarea", "disabled"]
+        "tags": [
+          "label",
+          "textarea",
+          "disabled"
+        ]
       }
     },
     {
@@ -1325,7 +1623,11 @@
         }
       ],
       "meta": {
-        "tags": ["label", "textarea", "button"]
+        "tags": [
+          "label",
+          "textarea",
+          "button"
+        ]
       }
     },
     {
@@ -1338,7 +1640,11 @@
         }
       ],
       "meta": {
-        "tags": ["label", "textarea", "button"]
+        "tags": [
+          "label",
+          "textarea",
+          "button"
+        ]
       }
     },
     {
@@ -1351,7 +1657,11 @@
         }
       ],
       "meta": {
-        "tags": ["label", "textarea", "button"]
+        "tags": [
+          "label",
+          "textarea",
+          "button"
+        ]
       }
     },
     {
@@ -1364,7 +1674,10 @@
         }
       ],
       "meta": {
-        "tags": ["label", "textarea"]
+        "tags": [
+          "label",
+          "textarea"
+        ]
       }
     },
     {
@@ -1377,7 +1690,10 @@
         }
       ],
       "meta": {
-        "tags": ["label", "textarea"]
+        "tags": [
+          "label",
+          "textarea"
+        ]
       }
     },
     {
@@ -1390,7 +1706,10 @@
         }
       ],
       "meta": {
-        "tags": ["label", "textarea"]
+        "tags": [
+          "label",
+          "textarea"
+        ]
       }
     },
     {
@@ -1403,7 +1722,10 @@
         }
       ],
       "meta": {
-        "tags": ["label", "textarea"]
+        "tags": [
+          "label",
+          "textarea"
+        ]
       }
     },
     {
@@ -1416,7 +1738,10 @@
         }
       ],
       "meta": {
-        "tags": ["label", "textarea"]
+        "tags": [
+          "label",
+          "textarea"
+        ]
       }
     },
     {
@@ -1429,7 +1754,11 @@
         }
       ],
       "meta": {
-        "tags": ["label", "textarea", "read-only"]
+        "tags": [
+          "label",
+          "textarea",
+          "read-only"
+        ]
       }
     },
     {
@@ -1442,7 +1771,10 @@
         }
       ],
       "meta": {
-        "tags": ["label", "textarea"]
+        "tags": [
+          "label",
+          "textarea"
+        ]
       }
     },
     {
@@ -1455,7 +1787,9 @@
         }
       ],
       "meta": {
-        "tags": ["button"],
+        "tags": [
+          "button"
+        ],
         "style": 2
       }
     },
@@ -1469,7 +1803,10 @@
         }
       ],
       "meta": {
-        "tags": ["button", "disabled"],
+        "tags": [
+          "button",
+          "disabled"
+        ],
         "style": 2
       }
     },
@@ -1483,7 +1820,9 @@
         }
       ],
       "meta": {
-        "tags": ["button"],
+        "tags": [
+          "button"
+        ],
         "style": 2
       }
     },
@@ -1497,7 +1836,9 @@
         }
       ],
       "meta": {
-        "tags": ["button"],
+        "tags": [
+          "button"
+        ],
         "style": 2
       }
     },
@@ -1511,7 +1852,10 @@
         }
       ],
       "meta": {
-        "tags": ["button", "delete"],
+        "tags": [
+          "button",
+          "delete"
+        ],
         "style": 2
       }
     },
@@ -1525,7 +1869,9 @@
         }
       ],
       "meta": {
-        "tags": ["button"],
+        "tags": [
+          "button"
+        ],
         "style": 2
       }
     },
@@ -1539,7 +1885,9 @@
         }
       ],
       "meta": {
-        "tags": ["button"],
+        "tags": [
+          "button"
+        ],
         "style": 2
       }
     },
@@ -1553,7 +1901,10 @@
         }
       ],
       "meta": {
-        "tags": ["button", "back"],
+        "tags": [
+          "button",
+          "back"
+        ],
         "style": 2
       }
     },
@@ -1567,7 +1918,10 @@
         }
       ],
       "meta": {
-        "tags": ["button", "next"],
+        "tags": [
+          "button",
+          "next"
+        ],
         "style": 2
       }
     },
@@ -1581,7 +1935,9 @@
         }
       ],
       "meta": {
-        "tags": ["button"],
+        "tags": [
+          "button"
+        ],
         "style": 2
       }
     },
@@ -1595,7 +1951,10 @@
         }
       ],
       "meta": {
-        "tags": ["button", "dropdown"],
+        "tags": [
+          "button",
+          "dropdown"
+        ],
         "style": 2
       }
     },
@@ -1609,7 +1968,9 @@
         }
       ],
       "meta": {
-        "tags": ["button"],
+        "tags": [
+          "button"
+        ],
         "style": 2
       }
     },
@@ -1623,7 +1984,10 @@
         }
       ],
       "meta": {
-        "tags": ["button", "loading"],
+        "tags": [
+          "button",
+          "loading"
+        ],
         "style": 2
       }
     },
@@ -1637,7 +2001,10 @@
         }
       ],
       "meta": {
-        "tags": ["button", "loading"],
+        "tags": [
+          "button",
+          "loading"
+        ],
         "style": 2
       }
     },
@@ -1651,7 +2018,10 @@
         }
       ],
       "meta": {
-        "tags": ["button", "counter"],
+        "tags": [
+          "button",
+          "counter"
+        ],
         "style": 2
       }
     },
@@ -1665,7 +2035,10 @@
         }
       ],
       "meta": {
-        "tags": ["button", "kbd"],
+        "tags": [
+          "button",
+          "kbd"
+        ],
         "style": 2
       }
     },
@@ -1679,7 +2052,12 @@
         }
       ],
       "meta": {
-        "tags": ["button", "user", "avatar", "profile"],
+        "tags": [
+          "button",
+          "user",
+          "avatar",
+          "profile"
+        ],
         "style": 2
       }
     },
@@ -1693,7 +2071,13 @@
         }
       ],
       "meta": {
-        "tags": ["button", "user", "avatar", "profile", "dropdown"],
+        "tags": [
+          "button",
+          "user",
+          "avatar",
+          "profile",
+          "dropdown"
+        ],
         "style": 2
       }
     },
@@ -1707,7 +2091,9 @@
         }
       ],
       "meta": {
-        "tags": ["button"],
+        "tags": [
+          "button"
+        ],
         "style": 2
       }
     },
@@ -1721,7 +2107,9 @@
         }
       ],
       "meta": {
-        "tags": ["button"],
+        "tags": [
+          "button"
+        ],
         "style": 2
       }
     },
@@ -1735,7 +2123,10 @@
         }
       ],
       "meta": {
-        "tags": ["button", "menu"],
+        "tags": [
+          "button",
+          "menu"
+        ],
         "style": 2
       }
     },
@@ -1749,7 +2140,10 @@
         }
       ],
       "meta": {
-        "tags": ["button", "tooltip"],
+        "tags": [
+          "button",
+          "tooltip"
+        ],
         "style": 2
       }
     },
@@ -1763,7 +2157,11 @@
         }
       ],
       "meta": {
-        "tags": ["button", "menu", "hamburger"],
+        "tags": [
+          "button",
+          "menu",
+          "hamburger"
+        ],
         "style": 2
       }
     },
@@ -1777,7 +2175,10 @@
         }
       ],
       "meta": {
-        "tags": ["button", "toggle"],
+        "tags": [
+          "button",
+          "toggle"
+        ],
         "style": 2
       }
     },
@@ -1791,7 +2192,11 @@
         }
       ],
       "meta": {
-        "tags": ["button", "vote", "counter"],
+        "tags": [
+          "button",
+          "vote",
+          "counter"
+        ],
         "style": 2
       }
     },
@@ -1805,7 +2210,11 @@
         }
       ],
       "meta": {
-        "tags": ["button", "vote", "counter"],
+        "tags": [
+          "button",
+          "vote",
+          "counter"
+        ],
         "style": 2
       }
     },
@@ -1819,7 +2228,11 @@
         }
       ],
       "meta": {
-        "tags": ["button", "volume", "controls"],
+        "tags": [
+          "button",
+          "volume",
+          "controls"
+        ],
         "style": 2
       }
     },
@@ -1833,7 +2246,10 @@
         }
       ],
       "meta": {
-        "tags": ["button", "copy"],
+        "tags": [
+          "button",
+          "copy"
+        ],
         "style": 2
       }
     },
@@ -1847,7 +2263,10 @@
         }
       ],
       "meta": {
-        "tags": ["button", "toggle group"],
+        "tags": [
+          "button",
+          "toggle group"
+        ],
         "style": 2
       }
     },
@@ -1861,7 +2280,10 @@
         }
       ],
       "meta": {
-        "tags": ["button", "toggle group"],
+        "tags": [
+          "button",
+          "toggle group"
+        ],
         "style": 2
       }
     },
@@ -1875,7 +2297,11 @@
         }
       ],
       "meta": {
-        "tags": ["button", "toggle group", "dropdown"],
+        "tags": [
+          "button",
+          "toggle group",
+          "dropdown"
+        ],
         "style": 2
       }
     },
@@ -1889,7 +2315,10 @@
         }
       ],
       "meta": {
-        "tags": ["button", "toggle group"],
+        "tags": [
+          "button",
+          "toggle group"
+        ],
         "style": 2
       }
     },
@@ -1903,7 +2332,10 @@
         }
       ],
       "meta": {
-        "tags": ["button", "toggle group"],
+        "tags": [
+          "button",
+          "toggle group"
+        ],
         "style": 2
       }
     },
@@ -1917,7 +2349,9 @@
         }
       ],
       "meta": {
-        "tags": ["button"],
+        "tags": [
+          "button"
+        ],
         "style": 2
       }
     },
@@ -1931,7 +2365,9 @@
         }
       ],
       "meta": {
-        "tags": ["button"],
+        "tags": [
+          "button"
+        ],
         "style": 2
       }
     },
@@ -1945,7 +2381,10 @@
         }
       ],
       "meta": {
-        "tags": ["button", "dropdown"],
+        "tags": [
+          "button",
+          "dropdown"
+        ],
         "style": 2
       }
     },
@@ -1959,7 +2398,11 @@
         }
       ],
       "meta": {
-        "tags": ["button", "dropdown", "counter"],
+        "tags": [
+          "button",
+          "dropdown",
+          "counter"
+        ],
         "style": 2
       }
     },
@@ -1973,7 +2416,10 @@
         }
       ],
       "meta": {
-        "tags": ["button", "previous"],
+        "tags": [
+          "button",
+          "previous"
+        ],
         "style": 2
       }
     },
@@ -1987,7 +2433,10 @@
         }
       ],
       "meta": {
-        "tags": ["button", "next"],
+        "tags": [
+          "button",
+          "next"
+        ],
         "style": 2
       }
     },
@@ -2001,7 +2450,11 @@
         }
       ],
       "meta": {
-        "tags": ["button", "like", "counter"],
+        "tags": [
+          "button",
+          "like",
+          "counter"
+        ],
         "style": 2
       }
     },
@@ -2015,7 +2468,11 @@
         }
       ],
       "meta": {
-        "tags": ["button", "like", "counter"],
+        "tags": [
+          "button",
+          "like",
+          "counter"
+        ],
         "style": 2
       }
     },
@@ -2029,7 +2486,12 @@
         }
       ],
       "meta": {
-        "tags": ["button", "social", "login", "authentication"],
+        "tags": [
+          "button",
+          "social",
+          "login",
+          "authentication"
+        ],
         "style": 2
       }
     },
@@ -2043,7 +2505,12 @@
         }
       ],
       "meta": {
-        "tags": ["button", "social", "login", "authentication"],
+        "tags": [
+          "button",
+          "social",
+          "login",
+          "authentication"
+        ],
         "style": 2
       }
     },
@@ -2057,7 +2524,12 @@
         }
       ],
       "meta": {
-        "tags": ["button", "social", "login", "authentication"],
+        "tags": [
+          "button",
+          "social",
+          "login",
+          "authentication"
+        ],
         "style": 2
       }
     },
@@ -2071,7 +2543,12 @@
         }
       ],
       "meta": {
-        "tags": ["button", "social", "login", "authentication"],
+        "tags": [
+          "button",
+          "social",
+          "login",
+          "authentication"
+        ],
         "style": 2
       }
     },
@@ -2085,7 +2562,10 @@
         }
       ],
       "meta": {
-        "tags": ["button", "collapsible"],
+        "tags": [
+          "button",
+          "collapsible"
+        ],
         "style": 2
       }
     },
@@ -2099,7 +2579,10 @@
         }
       ],
       "meta": {
-        "tags": ["button", "back"],
+        "tags": [
+          "button",
+          "back"
+        ],
         "style": 2
       }
     },
@@ -2113,7 +2596,14 @@
         }
       ],
       "meta": {
-        "tags": ["button", "upload", "user", "avatar", "profile", "image"],
+        "tags": [
+          "button",
+          "upload",
+          "user",
+          "avatar",
+          "profile",
+          "image"
+        ],
         "style": 2
       }
     },
@@ -2127,7 +2617,14 @@
         }
       ],
       "meta": {
-        "tags": ["button", "upload", "user", "avatar", "profile", "image"],
+        "tags": [
+          "button",
+          "upload",
+          "user",
+          "avatar",
+          "profile",
+          "image"
+        ],
         "style": 2
       }
     },
@@ -2141,7 +2638,9 @@
         }
       ],
       "meta": {
-        "tags": ["button"],
+        "tags": [
+          "button"
+        ],
         "style": 2
       }
     },
@@ -2155,7 +2654,9 @@
         }
       ],
       "meta": {
-        "tags": ["button"],
+        "tags": [
+          "button"
+        ],
         "style": 2
       }
     },
@@ -2169,7 +2670,11 @@
         }
       ],
       "meta": {
-        "tags": ["button", "dropdown", "notification"],
+        "tags": [
+          "button",
+          "dropdown",
+          "notification"
+        ],
         "style": 2
       }
     },
@@ -2183,7 +2688,11 @@
         }
       ],
       "meta": {
-        "tags": ["button", "toggle", "darkmode"],
+        "tags": [
+          "button",
+          "toggle",
+          "darkmode"
+        ],
         "style": 2
       }
     },
@@ -2197,7 +2706,10 @@
         }
       ],
       "meta": {
-        "tags": ["button", "dropdown"],
+        "tags": [
+          "button",
+          "dropdown"
+        ],
         "style": 2
       }
     },
@@ -2211,7 +2723,11 @@
         }
       ],
       "meta": {
-        "tags": ["checkbox", "label", "radix"]
+        "tags": [
+          "checkbox",
+          "label",
+          "radix"
+        ]
       }
     },
     {
@@ -2224,7 +2740,11 @@
         }
       ],
       "meta": {
-        "tags": ["checkbox", "label", "radix"]
+        "tags": [
+          "checkbox",
+          "label",
+          "radix"
+        ]
       }
     },
     {
@@ -2237,7 +2757,11 @@
         }
       ],
       "meta": {
-        "tags": ["checkbox", "label", "radix"]
+        "tags": [
+          "checkbox",
+          "label",
+          "radix"
+        ]
       }
     },
     {
@@ -2250,7 +2774,12 @@
         }
       ],
       "meta": {
-        "tags": ["checkbox", "label", "disabled", "radix"]
+        "tags": [
+          "checkbox",
+          "label",
+          "disabled",
+          "radix"
+        ]
       }
     },
     {
@@ -2263,7 +2792,11 @@
         }
       ],
       "meta": {
-        "tags": ["checkbox", "label", "radix"]
+        "tags": [
+          "checkbox",
+          "label",
+          "radix"
+        ]
       }
     },
     {
@@ -2276,7 +2809,11 @@
         }
       ],
       "meta": {
-        "tags": ["checkbox", "label", "radix"]
+        "tags": [
+          "checkbox",
+          "label",
+          "radix"
+        ]
       }
     },
     {
@@ -2289,7 +2826,13 @@
         }
       ],
       "meta": {
-        "tags": ["checkbox", "label", "login", "authentication", "radix"]
+        "tags": [
+          "checkbox",
+          "label",
+          "login",
+          "authentication",
+          "radix"
+        ]
       }
     },
     {
@@ -2302,7 +2845,11 @@
         }
       ],
       "meta": {
-        "tags": ["checkbox", "label", "radix"]
+        "tags": [
+          "checkbox",
+          "label",
+          "radix"
+        ]
       }
     },
     {
@@ -2315,7 +2862,11 @@
         }
       ],
       "meta": {
-        "tags": ["checkbox", "label", "radix"]
+        "tags": [
+          "checkbox",
+          "label",
+          "radix"
+        ]
       }
     },
     {
@@ -2328,7 +2879,11 @@
         }
       ],
       "meta": {
-        "tags": ["checkbox", "label", "radix"]
+        "tags": [
+          "checkbox",
+          "label",
+          "radix"
+        ]
       }
     },
     {
@@ -2341,7 +2896,12 @@
         }
       ],
       "meta": {
-        "tags": ["checkbox", "label", "collapsible", "radix"]
+        "tags": [
+          "checkbox",
+          "label",
+          "collapsible",
+          "radix"
+        ]
       }
     },
     {
@@ -2354,7 +2914,11 @@
         }
       ],
       "meta": {
-        "tags": ["checkbox", "label", "radix"]
+        "tags": [
+          "checkbox",
+          "label",
+          "radix"
+        ]
       }
     },
     {
@@ -2367,7 +2931,12 @@
         }
       ],
       "meta": {
-        "tags": ["checkbox", "label", "card", "radix"]
+        "tags": [
+          "checkbox",
+          "label",
+          "card",
+          "radix"
+        ]
       }
     },
     {
@@ -2380,7 +2949,12 @@
         }
       ],
       "meta": {
-        "tags": ["checkbox", "label", "card", "radix"]
+        "tags": [
+          "checkbox",
+          "label",
+          "card",
+          "radix"
+        ]
       }
     },
     {
@@ -2393,7 +2967,12 @@
         }
       ],
       "meta": {
-        "tags": ["checkbox", "label", "card", "radix"]
+        "tags": [
+          "checkbox",
+          "label",
+          "card",
+          "radix"
+        ]
       }
     },
     {
@@ -2406,7 +2985,12 @@
         }
       ],
       "meta": {
-        "tags": ["checkbox", "label", "card", "radix"]
+        "tags": [
+          "checkbox",
+          "label",
+          "card",
+          "radix"
+        ]
       }
     },
     {
@@ -2419,7 +3003,12 @@
         }
       ],
       "meta": {
-        "tags": ["checkbox", "label", "tree", "radix"]
+        "tags": [
+          "checkbox",
+          "label",
+          "tree",
+          "radix"
+        ]
       }
     },
     {
@@ -2432,7 +3021,13 @@
         }
       ],
       "meta": {
-        "tags": ["checkbox", "label", "week", "calendar", "radix"]
+        "tags": [
+          "checkbox",
+          "label",
+          "week",
+          "calendar",
+          "radix"
+        ]
       }
     },
     {
@@ -2445,7 +3040,13 @@
         }
       ],
       "meta": {
-        "tags": ["checkbox", "label", "toggle", "darkmode", "radix"]
+        "tags": [
+          "checkbox",
+          "label",
+          "toggle",
+          "darkmode",
+          "radix"
+        ]
       }
     },
     {
@@ -2458,7 +3059,11 @@
         }
       ],
       "meta": {
-        "tags": ["checkbox", "label", "radix"]
+        "tags": [
+          "checkbox",
+          "label",
+          "radix"
+        ]
       }
     },
     {
@@ -2471,7 +3076,11 @@
         }
       ],
       "meta": {
-        "tags": ["radio", "label", "radix"]
+        "tags": [
+          "radio",
+          "label",
+          "radix"
+        ]
       }
     },
     {
@@ -2484,7 +3093,11 @@
         }
       ],
       "meta": {
-        "tags": ["radio", "label", "radix"]
+        "tags": [
+          "radio",
+          "label",
+          "radix"
+        ]
       }
     },
     {
@@ -2497,7 +3110,11 @@
         }
       ],
       "meta": {
-        "tags": ["radio", "label", "radix"]
+        "tags": [
+          "radio",
+          "label",
+          "radix"
+        ]
       }
     },
     {
@@ -2510,7 +3127,11 @@
         }
       ],
       "meta": {
-        "tags": ["radio", "label", "radix"]
+        "tags": [
+          "radio",
+          "label",
+          "radix"
+        ]
       }
     },
     {
@@ -2523,7 +3144,12 @@
         }
       ],
       "meta": {
-        "tags": ["radio", "label", "collapsible", "radix"]
+        "tags": [
+          "radio",
+          "label",
+          "collapsible",
+          "radix"
+        ]
       }
     },
     {
@@ -2536,7 +3162,12 @@
         }
       ],
       "meta": {
-        "tags": ["radio", "label", "rating", "radix"]
+        "tags": [
+          "radio",
+          "label",
+          "rating",
+          "radix"
+        ]
       }
     },
     {
@@ -2549,7 +3180,13 @@
         }
       ],
       "meta": {
-        "tags": ["radio", "label", "color", "picker", "radix"]
+        "tags": [
+          "radio",
+          "label",
+          "color",
+          "picker",
+          "radix"
+        ]
       }
     },
     {
@@ -2562,7 +3199,12 @@
         }
       ],
       "meta": {
-        "tags": ["radio", "label", "card", "radix"]
+        "tags": [
+          "radio",
+          "label",
+          "card",
+          "radix"
+        ]
       }
     },
     {
@@ -2575,7 +3217,12 @@
         }
       ],
       "meta": {
-        "tags": ["radio", "label", "card", "radix"]
+        "tags": [
+          "radio",
+          "label",
+          "card",
+          "radix"
+        ]
       }
     },
     {
@@ -2588,7 +3235,12 @@
         }
       ],
       "meta": {
-        "tags": ["radio", "label", "card", "radix"]
+        "tags": [
+          "radio",
+          "label",
+          "card",
+          "radix"
+        ]
       }
     },
     {
@@ -2601,7 +3253,12 @@
         }
       ],
       "meta": {
-        "tags": ["radio", "label", "card", "radix"]
+        "tags": [
+          "radio",
+          "label",
+          "card",
+          "radix"
+        ]
       }
     },
     {
@@ -2614,7 +3271,14 @@
         }
       ],
       "meta": {
-        "tags": ["radio", "label", "card", "checkout", "payment", "radix"]
+        "tags": [
+          "radio",
+          "label",
+          "card",
+          "checkout",
+          "payment",
+          "radix"
+        ]
       }
     },
     {
@@ -2627,7 +3291,13 @@
         }
       ],
       "meta": {
-        "tags": ["radio", "label", "card", "pricing", "radix"]
+        "tags": [
+          "radio",
+          "label",
+          "card",
+          "pricing",
+          "radix"
+        ]
       }
     },
     {
@@ -2640,7 +3310,12 @@
         }
       ],
       "meta": {
-        "tags": ["radio", "label", "card", "radix"]
+        "tags": [
+          "radio",
+          "label",
+          "card",
+          "radix"
+        ]
       }
     },
     {
@@ -2653,7 +3328,12 @@
         }
       ],
       "meta": {
-        "tags": ["radio", "label", "pricing", "radix"]
+        "tags": [
+          "radio",
+          "label",
+          "pricing",
+          "radix"
+        ]
       }
     },
     {
@@ -2666,7 +3346,13 @@
         }
       ],
       "meta": {
-        "tags": ["radio", "label", "rating", "vote", "radix"]
+        "tags": [
+          "radio",
+          "label",
+          "rating",
+          "vote",
+          "radix"
+        ]
       }
     },
     {
@@ -2679,7 +3365,13 @@
         }
       ],
       "meta": {
-        "tags": ["radio", "label", "rating", "vote", "radix"]
+        "tags": [
+          "radio",
+          "label",
+          "rating",
+          "vote",
+          "radix"
+        ]
       }
     },
     {
@@ -2692,7 +3384,12 @@
         }
       ],
       "meta": {
-        "tags": ["radio", "label", "darkmode", "radix"]
+        "tags": [
+          "radio",
+          "label",
+          "darkmode",
+          "radix"
+        ]
       }
     },
     {
@@ -2705,7 +3402,13 @@
         }
       ],
       "meta": {
-        "tags": ["radio", "label", "pricing", "switch", "radix"],
+        "tags": [
+          "radio",
+          "label",
+          "pricing",
+          "switch",
+          "radix"
+        ],
         "style": 1
       }
     },
@@ -2719,7 +3422,13 @@
         }
       ],
       "meta": {
-        "tags": ["radio", "label", "rating", "vote", "radix"],
+        "tags": [
+          "radio",
+          "label",
+          "rating",
+          "vote",
+          "radix"
+        ],
         "style": 1
       }
     },
@@ -2733,7 +3442,10 @@
         }
       ],
       "meta": {
-        "tags": ["switch", "radix"],
+        "tags": [
+          "switch",
+          "radix"
+        ],
         "style": 1
       }
     },
@@ -2747,7 +3459,10 @@
         }
       ],
       "meta": {
-        "tags": ["switch", "radix"],
+        "tags": [
+          "switch",
+          "radix"
+        ],
         "style": 1
       }
     },
@@ -2761,7 +3476,10 @@
         }
       ],
       "meta": {
-        "tags": ["switch", "radix"],
+        "tags": [
+          "switch",
+          "radix"
+        ],
         "style": 1
       }
     },
@@ -2775,7 +3493,10 @@
         }
       ],
       "meta": {
-        "tags": ["switch", "radix"],
+        "tags": [
+          "switch",
+          "radix"
+        ],
         "style": 1
       }
     },
@@ -2789,7 +3510,10 @@
         }
       ],
       "meta": {
-        "tags": ["switch", "radix"],
+        "tags": [
+          "switch",
+          "radix"
+        ],
         "style": 1
       }
     },
@@ -2803,7 +3527,10 @@
         }
       ],
       "meta": {
-        "tags": ["switch", "radix"],
+        "tags": [
+          "switch",
+          "radix"
+        ],
         "style": 1
       }
     },
@@ -2817,7 +3544,10 @@
         }
       ],
       "meta": {
-        "tags": ["switch", "radix"],
+        "tags": [
+          "switch",
+          "radix"
+        ],
         "style": 1
       }
     },
@@ -2831,7 +3561,11 @@
         }
       ],
       "meta": {
-        "tags": ["switch", "label", "radix"],
+        "tags": [
+          "switch",
+          "label",
+          "radix"
+        ],
         "style": 1
       }
     },
@@ -2845,7 +3579,11 @@
         }
       ],
       "meta": {
-        "tags": ["switch", "label", "radix"],
+        "tags": [
+          "switch",
+          "label",
+          "radix"
+        ],
         "style": 1
       }
     },
@@ -2859,7 +3597,12 @@
         }
       ],
       "meta": {
-        "tags": ["switch", "label", "darkmode", "radix"],
+        "tags": [
+          "switch",
+          "label",
+          "darkmode",
+          "radix"
+        ],
         "style": 1
       }
     },
@@ -2873,7 +3616,12 @@
         }
       ],
       "meta": {
-        "tags": ["switch", "label", "darkmode", "radix"],
+        "tags": [
+          "switch",
+          "label",
+          "darkmode",
+          "radix"
+        ],
         "style": 1
       }
     },
@@ -2887,7 +3635,12 @@
         }
       ],
       "meta": {
-        "tags": ["switch", "label", "darkmode", "radix"],
+        "tags": [
+          "switch",
+          "label",
+          "darkmode",
+          "radix"
+        ],
         "style": 1
       }
     },
@@ -2901,7 +3654,12 @@
         }
       ],
       "meta": {
-        "tags": ["switch", "label", "darkmode", "radix"],
+        "tags": [
+          "switch",
+          "label",
+          "darkmode",
+          "radix"
+        ],
         "style": 1
       }
     },
@@ -2915,7 +3673,11 @@
         }
       ],
       "meta": {
-        "tags": ["switch", "label", "radix"],
+        "tags": [
+          "switch",
+          "label",
+          "radix"
+        ],
         "style": 1
       }
     },
@@ -2929,7 +3691,12 @@
         }
       ],
       "meta": {
-        "tags": ["switch", "label", "card", "radix"],
+        "tags": [
+          "switch",
+          "label",
+          "card",
+          "radix"
+        ],
         "style": 1
       }
     },
@@ -2943,7 +3710,12 @@
         }
       ],
       "meta": {
-        "tags": ["switch", "label", "card", "radix"],
+        "tags": [
+          "switch",
+          "label",
+          "card",
+          "radix"
+        ],
         "style": 1
       }
     },
@@ -2957,7 +3729,12 @@
         }
       ],
       "meta": {
-        "tags": ["switch", "label", "card", "radix"],
+        "tags": [
+          "switch",
+          "label",
+          "card",
+          "radix"
+        ],
         "style": 1
       }
     },
@@ -2971,7 +3748,11 @@
         }
       ],
       "meta": {
-        "tags": ["label", "select", "native select"]
+        "tags": [
+          "label",
+          "select",
+          "native select"
+        ]
       }
     },
     {
@@ -2984,7 +3765,11 @@
         }
       ],
       "meta": {
-        "tags": ["label", "select", "native select"]
+        "tags": [
+          "label",
+          "select",
+          "native select"
+        ]
       }
     },
     {
@@ -2997,7 +3782,12 @@
         }
       ],
       "meta": {
-        "tags": ["label", "select", "native select", "time"]
+        "tags": [
+          "label",
+          "select",
+          "native select",
+          "time"
+        ]
       }
     },
     {
@@ -3010,7 +3800,11 @@
         }
       ],
       "meta": {
-        "tags": ["label", "select", "native select"]
+        "tags": [
+          "label",
+          "select",
+          "native select"
+        ]
       }
     },
     {
@@ -3023,7 +3817,11 @@
         }
       ],
       "meta": {
-        "tags": ["label", "select", "native select"]
+        "tags": [
+          "label",
+          "select",
+          "native select"
+        ]
       }
     },
     {
@@ -3036,7 +3834,12 @@
         }
       ],
       "meta": {
-        "tags": ["label", "select", "native select", "error"]
+        "tags": [
+          "label",
+          "select",
+          "native select",
+          "error"
+        ]
       }
     },
     {
@@ -3049,7 +3852,11 @@
         }
       ],
       "meta": {
-        "tags": ["label", "select", "native select"]
+        "tags": [
+          "label",
+          "select",
+          "native select"
+        ]
       }
     },
     {
@@ -3062,7 +3869,12 @@
         }
       ],
       "meta": {
-        "tags": ["label", "select", "native select", "disabled"]
+        "tags": [
+          "label",
+          "select",
+          "native select",
+          "disabled"
+        ]
       }
     },
     {
@@ -3075,7 +3887,11 @@
         }
       ],
       "meta": {
-        "tags": ["label", "select", "native select"]
+        "tags": [
+          "label",
+          "select",
+          "native select"
+        ]
       }
     },
     {
@@ -3088,7 +3904,11 @@
         }
       ],
       "meta": {
-        "tags": ["label", "select", "native select"]
+        "tags": [
+          "label",
+          "select",
+          "native select"
+        ]
       }
     },
     {
@@ -3101,7 +3921,11 @@
         }
       ],
       "meta": {
-        "tags": ["label", "select", "native select"]
+        "tags": [
+          "label",
+          "select",
+          "native select"
+        ]
       }
     },
     {
@@ -3114,7 +3938,13 @@
         }
       ],
       "meta": {
-        "tags": ["label", "select", "native select", "timezone", "time"]
+        "tags": [
+          "label",
+          "select",
+          "native select",
+          "timezone",
+          "time"
+        ]
       }
     },
     {
@@ -3127,7 +3957,11 @@
         }
       ],
       "meta": {
-        "tags": ["label", "select", "native select"]
+        "tags": [
+          "label",
+          "select",
+          "native select"
+        ]
       }
     },
     {
@@ -3140,7 +3974,11 @@
         }
       ],
       "meta": {
-        "tags": ["label", "select", "native select"]
+        "tags": [
+          "label",
+          "select",
+          "native select"
+        ]
       }
     },
     {
@@ -3153,7 +3991,11 @@
         }
       ],
       "meta": {
-        "tags": ["label", "select", "radix"]
+        "tags": [
+          "label",
+          "select",
+          "radix"
+        ]
       }
     },
     {
@@ -3166,7 +4008,11 @@
         }
       ],
       "meta": {
-        "tags": ["label", "select", "radix"]
+        "tags": [
+          "label",
+          "select",
+          "radix"
+        ]
       }
     },
     {
@@ -3179,7 +4025,11 @@
         }
       ],
       "meta": {
-        "tags": ["label", "select", "radix"]
+        "tags": [
+          "label",
+          "select",
+          "radix"
+        ]
       }
     },
     {
@@ -3192,7 +4042,12 @@
         }
       ],
       "meta": {
-        "tags": ["label", "select", "helper", "radix"]
+        "tags": [
+          "label",
+          "select",
+          "helper",
+          "radix"
+        ]
       }
     },
     {
@@ -3205,7 +4060,11 @@
         }
       ],
       "meta": {
-        "tags": ["label", "select", "radix"]
+        "tags": [
+          "label",
+          "select",
+          "radix"
+        ]
       }
     },
     {
@@ -3218,7 +4077,11 @@
         }
       ],
       "meta": {
-        "tags": ["label", "select", "radix"]
+        "tags": [
+          "label",
+          "select",
+          "radix"
+        ]
       }
     },
     {
@@ -3231,7 +4094,11 @@
         }
       ],
       "meta": {
-        "tags": ["label", "select", "radix"]
+        "tags": [
+          "label",
+          "select",
+          "radix"
+        ]
       }
     },
     {
@@ -3244,7 +4111,12 @@
         }
       ],
       "meta": {
-        "tags": ["label", "select", "disabled", "radix"]
+        "tags": [
+          "label",
+          "select",
+          "disabled",
+          "radix"
+        ]
       }
     },
     {
@@ -3257,7 +4129,12 @@
         }
       ],
       "meta": {
-        "tags": ["label", "select", "required", "radix"]
+        "tags": [
+          "label",
+          "select",
+          "required",
+          "radix"
+        ]
       }
     },
     {
@@ -3270,7 +4147,11 @@
         }
       ],
       "meta": {
-        "tags": ["label", "select", "radix"]
+        "tags": [
+          "label",
+          "select",
+          "radix"
+        ]
       }
     },
     {
@@ -3283,7 +4164,11 @@
         }
       ],
       "meta": {
-        "tags": ["label", "select", "radix"]
+        "tags": [
+          "label",
+          "select",
+          "radix"
+        ]
       }
     },
     {
@@ -3296,7 +4181,11 @@
         }
       ],
       "meta": {
-        "tags": ["label", "select", "radix"]
+        "tags": [
+          "label",
+          "select",
+          "radix"
+        ]
       }
     },
     {
@@ -3309,7 +4198,12 @@
         }
       ],
       "meta": {
-        "tags": ["label", "select", "disabled", "radix"]
+        "tags": [
+          "label",
+          "select",
+          "disabled",
+          "radix"
+        ]
       }
     },
     {
@@ -3322,7 +4216,11 @@
         }
       ],
       "meta": {
-        "tags": ["label", "select", "radix"]
+        "tags": [
+          "label",
+          "select",
+          "radix"
+        ]
       }
     },
     {
@@ -3335,7 +4233,11 @@
         }
       ],
       "meta": {
-        "tags": ["label", "select", "radix"]
+        "tags": [
+          "label",
+          "select",
+          "radix"
+        ]
       }
     },
     {
@@ -3348,7 +4250,13 @@
         }
       ],
       "meta": {
-        "tags": ["label", "select", "timezone", "time", "radix"]
+        "tags": [
+          "label",
+          "select",
+          "timezone",
+          "time",
+          "radix"
+        ]
       }
     },
     {
@@ -3361,7 +4269,11 @@
         }
       ],
       "meta": {
-        "tags": ["label", "select", "radix"]
+        "tags": [
+          "label",
+          "select",
+          "radix"
+        ]
       }
     },
     {
@@ -3374,7 +4286,12 @@
         }
       ],
       "meta": {
-        "tags": ["label", "select", "status", "radix"]
+        "tags": [
+          "label",
+          "select",
+          "status",
+          "radix"
+        ]
       }
     },
     {
@@ -3387,7 +4304,11 @@
         }
       ],
       "meta": {
-        "tags": ["label", "select", "radix"]
+        "tags": [
+          "label",
+          "select",
+          "radix"
+        ]
       }
     },
     {
@@ -3400,7 +4321,11 @@
         }
       ],
       "meta": {
-        "tags": ["label", "select", "radix"]
+        "tags": [
+          "label",
+          "select",
+          "radix"
+        ]
       }
     },
     {
@@ -3413,7 +4338,11 @@
         }
       ],
       "meta": {
-        "tags": ["label", "select", "radix"]
+        "tags": [
+          "label",
+          "select",
+          "radix"
+        ]
       }
     },
     {
@@ -3426,7 +4355,11 @@
         }
       ],
       "meta": {
-        "tags": ["label", "select", "radix"]
+        "tags": [
+          "label",
+          "select",
+          "radix"
+        ]
       }
     },
     {
@@ -3439,7 +4372,12 @@
         }
       ],
       "meta": {
-        "tags": ["label", "select", "flag", "radix"]
+        "tags": [
+          "label",
+          "select",
+          "flag",
+          "radix"
+        ]
       }
     },
     {
@@ -3452,7 +4390,14 @@
         }
       ],
       "meta": {
-        "tags": ["label", "select", "user", "avatar", "profile", "radix"]
+        "tags": [
+          "label",
+          "select",
+          "user",
+          "avatar",
+          "profile",
+          "radix"
+        ]
       }
     },
     {
@@ -3465,7 +4410,14 @@
         }
       ],
       "meta": {
-        "tags": ["label", "select", "user", "avatar", "profile", "radix"]
+        "tags": [
+          "label",
+          "select",
+          "user",
+          "avatar",
+          "profile",
+          "radix"
+        ]
       }
     },
     {
@@ -3478,7 +4430,14 @@
         }
       ],
       "meta": {
-        "tags": ["label", "select", "user", "avatar", "profile", "radix"]
+        "tags": [
+          "label",
+          "select",
+          "user",
+          "avatar",
+          "profile",
+          "radix"
+        ]
       }
     },
     {
@@ -3648,7 +4607,12 @@
         }
       ],
       "meta": {
-        "tags": ["label", "select", "multiselect", "native select"]
+        "tags": [
+          "label",
+          "select",
+          "multiselect",
+          "native select"
+        ]
       }
     },
     {
@@ -3661,7 +4625,12 @@
         }
       ],
       "meta": {
-        "tags": ["label", "select", "multiselect", "react aria"]
+        "tags": [
+          "label",
+          "select",
+          "multiselect",
+          "react aria"
+        ]
       }
     },
     {
@@ -3674,7 +4643,12 @@
         }
       ],
       "meta": {
-        "tags": ["label", "select", "multiselect", "react aria"]
+        "tags": [
+          "label",
+          "select",
+          "multiselect",
+          "react aria"
+        ]
       }
     },
     {
@@ -3687,7 +4661,12 @@
         }
       ],
       "meta": {
-        "tags": ["label", "select", "multiselect", "react aria"]
+        "tags": [
+          "label",
+          "select",
+          "multiselect",
+          "react aria"
+        ]
       }
     },
     {
@@ -3700,7 +4679,11 @@
         }
       ],
       "meta": {
-        "tags": ["slider", "label", "radix"]
+        "tags": [
+          "slider",
+          "label",
+          "radix"
+        ]
       }
     },
     {
@@ -3713,7 +4696,12 @@
         }
       ],
       "meta": {
-        "tags": ["slider", "label", "disabled", "radix"]
+        "tags": [
+          "slider",
+          "label",
+          "disabled",
+          "radix"
+        ]
       }
     },
     {
@@ -3726,7 +4714,11 @@
         }
       ],
       "meta": {
-        "tags": ["slider", "label", "radix"]
+        "tags": [
+          "slider",
+          "label",
+          "radix"
+        ]
       }
     },
     {
@@ -3739,7 +4731,11 @@
         }
       ],
       "meta": {
-        "tags": ["slider", "label", "radix"]
+        "tags": [
+          "slider",
+          "label",
+          "radix"
+        ]
       }
     },
     {
@@ -3752,7 +4748,11 @@
         }
       ],
       "meta": {
-        "tags": ["slider", "label", "radix"]
+        "tags": [
+          "slider",
+          "label",
+          "radix"
+        ]
       }
     },
     {
@@ -3765,7 +4765,11 @@
         }
       ],
       "meta": {
-        "tags": ["slider", "label", "radix"]
+        "tags": [
+          "slider",
+          "label",
+          "radix"
+        ]
       }
     },
     {
@@ -3778,7 +4782,11 @@
         }
       ],
       "meta": {
-        "tags": ["slider", "label", "radix"]
+        "tags": [
+          "slider",
+          "label",
+          "radix"
+        ]
       }
     },
     {
@@ -3791,7 +4799,11 @@
         }
       ],
       "meta": {
-        "tags": ["slider", "label", "radix"]
+        "tags": [
+          "slider",
+          "label",
+          "radix"
+        ]
       }
     },
     {
@@ -3804,7 +4816,11 @@
         }
       ],
       "meta": {
-        "tags": ["slider", "label", "radix"]
+        "tags": [
+          "slider",
+          "label",
+          "radix"
+        ]
       }
     },
     {
@@ -3817,7 +4833,12 @@
         }
       ],
       "meta": {
-        "tags": ["slider", "label", "tooltip", "radix"]
+        "tags": [
+          "slider",
+          "label",
+          "tooltip",
+          "radix"
+        ]
       }
     },
     {
@@ -3830,7 +4851,13 @@
         }
       ],
       "meta": {
-        "tags": ["slider", "range slider", "label", "range", "radix"]
+        "tags": [
+          "slider",
+          "range slider",
+          "label",
+          "range",
+          "radix"
+        ]
       }
     },
     {
@@ -3843,7 +4870,13 @@
         }
       ],
       "meta": {
-        "tags": ["slider", "range slider", "label", "range", "radix"]
+        "tags": [
+          "slider",
+          "range slider",
+          "label",
+          "range",
+          "radix"
+        ]
       }
     },
     {
@@ -3856,7 +4889,13 @@
         }
       ],
       "meta": {
-        "tags": ["slider", "label", "volume", "controls", "radix"]
+        "tags": [
+          "slider",
+          "label",
+          "volume",
+          "controls",
+          "radix"
+        ]
       }
     },
     {
@@ -3869,7 +4908,13 @@
         }
       ],
       "meta": {
-        "tags": ["slider", "range slider", "label", "range", "radix"]
+        "tags": [
+          "slider",
+          "range slider",
+          "label",
+          "range",
+          "radix"
+        ]
       }
     },
     {
@@ -3882,7 +4927,15 @@
         }
       ],
       "meta": {
-        "tags": ["slider", "label", "button", "input", "tooltip", "reset", "radix"]
+        "tags": [
+          "slider",
+          "label",
+          "button",
+          "input",
+          "tooltip",
+          "reset",
+          "radix"
+        ]
       }
     },
     {
@@ -3895,7 +4948,12 @@
         }
       ],
       "meta": {
-        "tags": ["slider", "label", "input", "radix"]
+        "tags": [
+          "slider",
+          "label",
+          "input",
+          "radix"
+        ]
       }
     },
     {
@@ -3908,7 +4966,13 @@
         }
       ],
       "meta": {
-        "tags": ["slider", "label", "vote", "rating", "radix"]
+        "tags": [
+          "slider",
+          "label",
+          "vote",
+          "rating",
+          "radix"
+        ]
       }
     },
     {
@@ -3921,7 +4985,13 @@
         }
       ],
       "meta": {
-        "tags": ["slider", "label", "vote", "rating", "radix"]
+        "tags": [
+          "slider",
+          "label",
+          "vote",
+          "rating",
+          "radix"
+        ]
       }
     },
     {
@@ -3934,7 +5004,14 @@
         }
       ],
       "meta": {
-        "tags": ["slider", "range slider", "label", "input", "range", "radix"]
+        "tags": [
+          "slider",
+          "range slider",
+          "label",
+          "input",
+          "range",
+          "radix"
+        ]
       }
     },
     {
@@ -3947,7 +5024,13 @@
         }
       ],
       "meta": {
-        "tags": ["slider", "label", "button", "pricing", "radix"]
+        "tags": [
+          "slider",
+          "label",
+          "button",
+          "pricing",
+          "radix"
+        ]
       }
     },
     {
@@ -3960,7 +5043,13 @@
         }
       ],
       "meta": {
-        "tags": ["slider", "range slider", "label", "button", "radix"]
+        "tags": [
+          "slider",
+          "range slider",
+          "label",
+          "button",
+          "radix"
+        ]
       }
     },
     {
@@ -3973,7 +5062,12 @@
         }
       ],
       "meta": {
-        "tags": ["slider", "vertical slider", "label", "radix"]
+        "tags": [
+          "slider",
+          "vertical slider",
+          "label",
+          "radix"
+        ]
       }
     },
     {
@@ -3986,7 +5080,13 @@
         }
       ],
       "meta": {
-        "tags": ["slider", "vertical slider", "label", "input", "radix"]
+        "tags": [
+          "slider",
+          "vertical slider",
+          "label",
+          "input",
+          "radix"
+        ]
       }
     },
     {
@@ -3999,7 +5099,13 @@
         }
       ],
       "meta": {
-        "tags": ["slider", "vertical slider", "range slider", "label", "radix"]
+        "tags": [
+          "slider",
+          "vertical slider",
+          "range slider",
+          "label",
+          "radix"
+        ]
       }
     },
     {
@@ -4012,7 +5118,14 @@
         }
       ],
       "meta": {
-        "tags": ["slider", "label", "input", "button", "reset", "radix"]
+        "tags": [
+          "slider",
+          "label",
+          "input",
+          "button",
+          "reset",
+          "radix"
+        ]
       }
     },
     {
@@ -4025,7 +5138,13 @@
         }
       ],
       "meta": {
-        "tags": ["slider", "label", "input", "button", "radix"]
+        "tags": [
+          "slider",
+          "label",
+          "input",
+          "button",
+          "radix"
+        ]
       }
     },
     {
@@ -4038,7 +5157,12 @@
         }
       ],
       "meta": {
-        "tags": ["slider", "label", "equalizer", "radix"]
+        "tags": [
+          "slider",
+          "label",
+          "equalizer",
+          "radix"
+        ]
       }
     },
     {
@@ -4051,7 +5175,10 @@
         }
       ],
       "meta": {
-        "tags": ["alert", "warning"],
+        "tags": [
+          "alert",
+          "warning"
+        ],
         "colSpan": 2
       }
     },
@@ -4065,7 +5192,10 @@
         }
       ],
       "meta": {
-        "tags": ["alert", "warning"],
+        "tags": [
+          "alert",
+          "warning"
+        ],
         "colSpan": 2
       }
     },
@@ -4079,7 +5209,10 @@
         }
       ],
       "meta": {
-        "tags": ["alert", "error"],
+        "tags": [
+          "alert",
+          "error"
+        ],
         "colSpan": 2
       }
     },
@@ -4093,7 +5226,10 @@
         }
       ],
       "meta": {
-        "tags": ["alert", "error"],
+        "tags": [
+          "alert",
+          "error"
+        ],
         "colSpan": 2
       }
     },
@@ -4107,7 +5243,10 @@
         }
       ],
       "meta": {
-        "tags": ["alert", "success"],
+        "tags": [
+          "alert",
+          "success"
+        ],
         "colSpan": 2
       }
     },
@@ -4121,7 +5260,10 @@
         }
       ],
       "meta": {
-        "tags": ["alert", "success"],
+        "tags": [
+          "alert",
+          "success"
+        ],
         "colSpan": 2
       }
     },
@@ -4135,7 +5277,10 @@
         }
       ],
       "meta": {
-        "tags": ["alert", "info"],
+        "tags": [
+          "alert",
+          "info"
+        ],
         "colSpan": 2
       }
     },
@@ -4149,7 +5294,10 @@
         }
       ],
       "meta": {
-        "tags": ["alert", "info"],
+        "tags": [
+          "alert",
+          "info"
+        ],
         "colSpan": 2
       }
     },
@@ -4163,7 +5311,10 @@
         }
       ],
       "meta": {
-        "tags": ["alert", "warning"],
+        "tags": [
+          "alert",
+          "warning"
+        ],
         "colSpan": 2
       }
     },
@@ -4177,7 +5328,10 @@
         }
       ],
       "meta": {
-        "tags": ["alert", "warning"],
+        "tags": [
+          "alert",
+          "warning"
+        ],
         "colSpan": 2
       }
     },
@@ -4191,7 +5345,12 @@
         }
       ],
       "meta": {
-        "tags": ["alert", "error", "signup", "authentication"],
+        "tags": [
+          "alert",
+          "error",
+          "signup",
+          "authentication"
+        ],
         "colSpan": 2
       }
     },
@@ -4205,7 +5364,12 @@
         }
       ],
       "meta": {
-        "tags": ["alert", "error", "signup", "authentication"],
+        "tags": [
+          "alert",
+          "error",
+          "signup",
+          "authentication"
+        ],
         "colSpan": 2
       }
     },
@@ -4219,7 +5383,10 @@
         }
       ],
       "meta": {
-        "tags": ["notification", "warning"],
+        "tags": [
+          "notification",
+          "warning"
+        ],
         "colSpan": 2,
         "style": 1
       }
@@ -4234,7 +5401,10 @@
         }
       ],
       "meta": {
-        "tags": ["notification", "error"],
+        "tags": [
+          "notification",
+          "error"
+        ],
         "colSpan": 2,
         "style": 1
       }
@@ -4249,7 +5419,10 @@
         }
       ],
       "meta": {
-        "tags": ["notification", "success"],
+        "tags": [
+          "notification",
+          "success"
+        ],
         "colSpan": 2,
         "style": 1
       }
@@ -4264,7 +5437,10 @@
         }
       ],
       "meta": {
-        "tags": ["notification", "info"],
+        "tags": [
+          "notification",
+          "info"
+        ],
         "colSpan": 2,
         "style": 1
       }
@@ -4279,7 +5455,10 @@
         }
       ],
       "meta": {
-        "tags": ["notification", "warning"],
+        "tags": [
+          "notification",
+          "warning"
+        ],
         "colSpan": 2,
         "style": 1
       }
@@ -4294,7 +5473,10 @@
         }
       ],
       "meta": {
-        "tags": ["notification", "error"],
+        "tags": [
+          "notification",
+          "error"
+        ],
         "colSpan": 2,
         "style": 1
       }
@@ -4309,7 +5491,10 @@
         }
       ],
       "meta": {
-        "tags": ["notification", "success"],
+        "tags": [
+          "notification",
+          "success"
+        ],
         "colSpan": 2,
         "style": 1
       }
@@ -4324,7 +5509,10 @@
         }
       ],
       "meta": {
-        "tags": ["notification", "info"],
+        "tags": [
+          "notification",
+          "info"
+        ],
         "colSpan": 2,
         "style": 1
       }
@@ -4339,7 +5527,11 @@
         }
       ],
       "meta": {
-        "tags": ["notification", "button", "success"],
+        "tags": [
+          "notification",
+          "button",
+          "success"
+        ],
         "colSpan": 2,
         "style": 1
       }
@@ -4354,7 +5546,10 @@
         }
       ],
       "meta": {
-        "tags": ["notification", "success"],
+        "tags": [
+          "notification",
+          "success"
+        ],
         "colSpan": 2,
         "style": 1
       }
@@ -4369,7 +5564,11 @@
         }
       ],
       "meta": {
-        "tags": ["notification", "button", "warning"],
+        "tags": [
+          "notification",
+          "button",
+          "warning"
+        ],
         "colSpan": 2,
         "style": 1
       }
@@ -4384,7 +5583,11 @@
         }
       ],
       "meta": {
-        "tags": ["notification", "button", "error"],
+        "tags": [
+          "notification",
+          "button",
+          "error"
+        ],
         "colSpan": 2,
         "style": 1
       }
@@ -4399,7 +5602,11 @@
         }
       ],
       "meta": {
-        "tags": ["notification", "button", "success"],
+        "tags": [
+          "notification",
+          "button",
+          "success"
+        ],
         "colSpan": 2,
         "style": 1
       }
@@ -4414,7 +5621,11 @@
         }
       ],
       "meta": {
-        "tags": ["notification", "button", "info"],
+        "tags": [
+          "notification",
+          "button",
+          "info"
+        ],
         "colSpan": 2,
         "style": 1
       }
@@ -4429,7 +5640,13 @@
         }
       ],
       "meta": {
-        "tags": ["notification", "button", "cookies", "gdpr", "privacy"],
+        "tags": [
+          "notification",
+          "button",
+          "cookies",
+          "gdpr",
+          "privacy"
+        ],
         "colSpan": 2,
         "style": 1
       }
@@ -4444,7 +5661,11 @@
         }
       ],
       "meta": {
-        "tags": ["notification", "button", "info"],
+        "tags": [
+          "notification",
+          "button",
+          "info"
+        ],
         "colSpan": 2,
         "style": 1
       }
@@ -4459,7 +5680,10 @@
         }
       ],
       "meta": {
-        "tags": ["notification", "button"],
+        "tags": [
+          "notification",
+          "button"
+        ],
         "colSpan": 2,
         "style": 1
       }
@@ -4474,7 +5698,10 @@
         }
       ],
       "meta": {
-        "tags": ["notification", "button"],
+        "tags": [
+          "notification",
+          "button"
+        ],
         "colSpan": 2,
         "style": 1
       }
@@ -4489,7 +5716,11 @@
         }
       ],
       "meta": {
-        "tags": ["notification", "toast", "radix"],
+        "tags": [
+          "notification",
+          "toast",
+          "radix"
+        ],
         "colSpan": 2,
         "style": 1
       }
@@ -4504,7 +5735,12 @@
         }
       ],
       "meta": {
-        "tags": ["notification", "toast", "success", "radix"],
+        "tags": [
+          "notification",
+          "toast",
+          "success",
+          "radix"
+        ],
         "colSpan": 2,
         "style": 1
       }
@@ -4519,7 +5755,12 @@
         }
       ],
       "meta": {
-        "tags": ["notification", "toast", "sonner", "radix"],
+        "tags": [
+          "notification",
+          "toast",
+          "sonner",
+          "radix"
+        ],
         "colSpan": 2,
         "style": 1
       }
@@ -4534,7 +5775,13 @@
         }
       ],
       "meta": {
-        "tags": ["notification", "toast", "sonner", "success", "radix"],
+        "tags": [
+          "notification",
+          "toast",
+          "sonner",
+          "success",
+          "radix"
+        ],
         "colSpan": 2,
         "style": 1
       }
@@ -4549,7 +5796,12 @@
         }
       ],
       "meta": {
-        "tags": ["banner", "cookies", "gdpr", "privacy"],
+        "tags": [
+          "banner",
+          "cookies",
+          "gdpr",
+          "privacy"
+        ],
         "colSpan": 3
       }
     },
@@ -4563,7 +5815,9 @@
         }
       ],
       "meta": {
-        "tags": ["banner"],
+        "tags": [
+          "banner"
+        ],
         "colSpan": 3
       }
     },
@@ -4577,7 +5831,9 @@
         }
       ],
       "meta": {
-        "tags": ["banner"],
+        "tags": [
+          "banner"
+        ],
         "colSpan": 3
       }
     },
@@ -4591,7 +5847,9 @@
         }
       ],
       "meta": {
-        "tags": ["banner"],
+        "tags": [
+          "banner"
+        ],
         "colSpan": 3
       }
     },
@@ -4605,7 +5863,9 @@
         }
       ],
       "meta": {
-        "tags": ["banner"],
+        "tags": [
+          "banner"
+        ],
         "colSpan": 3
       }
     },
@@ -4619,7 +5879,9 @@
         }
       ],
       "meta": {
-        "tags": ["banner"],
+        "tags": [
+          "banner"
+        ],
         "colSpan": 3
       }
     },
@@ -4633,7 +5895,9 @@
         }
       ],
       "meta": {
-        "tags": ["banner"],
+        "tags": [
+          "banner"
+        ],
         "colSpan": 3
       }
     },
@@ -4647,7 +5911,9 @@
         }
       ],
       "meta": {
-        "tags": ["banner"],
+        "tags": [
+          "banner"
+        ],
         "colSpan": 3
       }
     },
@@ -4661,7 +5927,9 @@
         }
       ],
       "meta": {
-        "tags": ["banner"],
+        "tags": [
+          "banner"
+        ],
         "colSpan": 3
       }
     },
@@ -4675,7 +5943,11 @@
         }
       ],
       "meta": {
-        "tags": ["banner", "countdown", "sale"],
+        "tags": [
+          "banner",
+          "countdown",
+          "sale"
+        ],
         "colSpan": 3
       }
     },
@@ -4689,7 +5961,11 @@
         }
       ],
       "meta": {
-        "tags": ["banner", "newsletter", "subscribe"],
+        "tags": [
+          "banner",
+          "newsletter",
+          "subscribe"
+        ],
         "colSpan": 3
       }
     },
@@ -4703,7 +5979,9 @@
         }
       ],
       "meta": {
-        "tags": ["banner"],
+        "tags": [
+          "banner"
+        ],
         "colSpan": 3
       }
     },
@@ -4717,7 +5995,13 @@
         }
       ],
       "meta": {
-        "tags": ["dialog", "modal", "alert", "alert dialog", "radix"],
+        "tags": [
+          "dialog",
+          "modal",
+          "alert",
+          "alert dialog",
+          "radix"
+        ],
         "style": 1
       }
     },
@@ -4731,7 +6015,13 @@
         }
       ],
       "meta": {
-        "tags": ["dialog", "modal", "alert", "alert dialog", "radix"],
+        "tags": [
+          "dialog",
+          "modal",
+          "alert",
+          "alert dialog",
+          "radix"
+        ],
         "style": 1
       }
     },
@@ -4745,7 +6035,11 @@
         }
       ],
       "meta": {
-        "tags": ["dialog", "modal", "radix"],
+        "tags": [
+          "dialog",
+          "modal",
+          "radix"
+        ],
         "style": 1
       }
     },
@@ -4759,7 +6053,11 @@
         }
       ],
       "meta": {
-        "tags": ["dialog", "modal", "radix"],
+        "tags": [
+          "dialog",
+          "modal",
+          "radix"
+        ],
         "style": 1
       }
     },
@@ -4773,7 +6071,11 @@
         }
       ],
       "meta": {
-        "tags": ["dialog", "modal", "radix"],
+        "tags": [
+          "dialog",
+          "modal",
+          "radix"
+        ],
         "style": 1
       }
     },
@@ -4787,7 +6089,11 @@
         }
       ],
       "meta": {
-        "tags": ["dialog", "modal", "radix"],
+        "tags": [
+          "dialog",
+          "modal",
+          "radix"
+        ],
         "style": 1
       }
     },
@@ -4801,7 +6107,11 @@
         }
       ],
       "meta": {
-        "tags": ["dialog", "modal", "radix"],
+        "tags": [
+          "dialog",
+          "modal",
+          "radix"
+        ],
         "style": 1
       }
     },
@@ -4815,7 +6125,12 @@
         }
       ],
       "meta": {
-        "tags": ["dialog", "modal", "delete", "radix"],
+        "tags": [
+          "dialog",
+          "modal",
+          "delete",
+          "radix"
+        ],
         "style": 1
       }
     },
@@ -4829,7 +6144,14 @@
         }
       ],
       "meta": {
-        "tags": ["dialog", "modal", "newsletter", "subscribe", "form", "radix"],
+        "tags": [
+          "dialog",
+          "modal",
+          "newsletter",
+          "subscribe",
+          "form",
+          "radix"
+        ],
         "style": 1
       }
     },
@@ -4843,7 +6165,13 @@
         }
       ],
       "meta": {
-        "tags": ["dialog", "modal", "feedback", "form", "radix"],
+        "tags": [
+          "dialog",
+          "modal",
+          "feedback",
+          "form",
+          "radix"
+        ],
         "style": 1
       }
     },
@@ -4857,7 +6185,14 @@
         }
       ],
       "meta": {
-        "tags": ["dialog", "modal", "rating", "feedback", "form", "radix"],
+        "tags": [
+          "dialog",
+          "modal",
+          "rating",
+          "feedback",
+          "form",
+          "radix"
+        ],
         "style": 1
       }
     },
@@ -4871,7 +6206,12 @@
         }
       ],
       "meta": {
-        "tags": ["dialog", "modal", "otp", "radix"],
+        "tags": [
+          "dialog",
+          "modal",
+          "otp",
+          "radix"
+        ],
         "style": 1
       }
     },
@@ -4885,7 +6225,14 @@
         }
       ],
       "meta": {
-        "tags": ["dialog", "modal", "signup", "authentication", "form", "radix"],
+        "tags": [
+          "dialog",
+          "modal",
+          "signup",
+          "authentication",
+          "form",
+          "radix"
+        ],
         "style": 1
       }
     },
@@ -4899,7 +6246,14 @@
         }
       ],
       "meta": {
-        "tags": ["dialog", "modal", "login", "authentication", "form", "radix"],
+        "tags": [
+          "dialog",
+          "modal",
+          "login",
+          "authentication",
+          "form",
+          "radix"
+        ],
         "style": 1
       }
     },
@@ -4913,7 +6267,14 @@
         }
       ],
       "meta": {
-        "tags": ["dialog", "modal", "form", "user", "team", "radix"],
+        "tags": [
+          "dialog",
+          "modal",
+          "form",
+          "user",
+          "team",
+          "radix"
+        ],
         "style": 1
       }
     },
@@ -4927,7 +6288,15 @@
         }
       ],
       "meta": {
-        "tags": ["dialog", "modal", "checkout", "payment", "credit card", "form", "radix"],
+        "tags": [
+          "dialog",
+          "modal",
+          "checkout",
+          "payment",
+          "credit card",
+          "form",
+          "radix"
+        ],
         "style": 1
       }
     },
@@ -4941,7 +6310,15 @@
         }
       ],
       "meta": {
-        "tags": ["dialog", "modal", "checkout", "payment", "credit card", "form", "radix"],
+        "tags": [
+          "dialog",
+          "modal",
+          "checkout",
+          "payment",
+          "credit card",
+          "form",
+          "radix"
+        ],
         "style": 1
       }
     },
@@ -4955,7 +6332,12 @@
         }
       ],
       "meta": {
-        "tags": ["dialog", "modal", "user", "radix"],
+        "tags": [
+          "dialog",
+          "modal",
+          "user",
+          "radix"
+        ],
         "style": 1
       }
     },
@@ -4969,7 +6351,16 @@
         }
       ],
       "meta": {
-        "tags": ["dialog", "modal", "user", "profile", "image", "avatar", "form", "radix"],
+        "tags": [
+          "dialog",
+          "modal",
+          "user",
+          "profile",
+          "image",
+          "avatar",
+          "form",
+          "radix"
+        ],
         "style": 1
       }
     },
@@ -4983,7 +6374,12 @@
         }
       ],
       "meta": {
-        "tags": ["dialog", "modal", "onboarding", "radix"],
+        "tags": [
+          "dialog",
+          "modal",
+          "onboarding",
+          "radix"
+        ],
         "style": 1
       }
     },
@@ -5021,7 +6417,10 @@
         }
       ],
       "meta": {
-        "tags": ["accordion", "radix"],
+        "tags": [
+          "accordion",
+          "radix"
+        ],
         "colSpan": 2
       }
     },
@@ -5035,7 +6434,10 @@
         }
       ],
       "meta": {
-        "tags": ["accordion", "radix"],
+        "tags": [
+          "accordion",
+          "radix"
+        ],
         "colSpan": 2
       }
     },
@@ -5049,7 +6451,10 @@
         }
       ],
       "meta": {
-        "tags": ["accordion", "radix"],
+        "tags": [
+          "accordion",
+          "radix"
+        ],
         "colSpan": 2
       }
     },
@@ -5063,7 +6468,10 @@
         }
       ],
       "meta": {
-        "tags": ["accordion", "radix"],
+        "tags": [
+          "accordion",
+          "radix"
+        ],
         "colSpan": 2
       }
     },
@@ -5077,7 +6485,10 @@
         }
       ],
       "meta": {
-        "tags": ["accordion", "radix"],
+        "tags": [
+          "accordion",
+          "radix"
+        ],
         "colSpan": 2
       }
     },
@@ -5091,7 +6502,10 @@
         }
       ],
       "meta": {
-        "tags": ["accordion", "radix"],
+        "tags": [
+          "accordion",
+          "radix"
+        ],
         "colSpan": 2
       }
     },
@@ -5105,7 +6519,10 @@
         }
       ],
       "meta": {
-        "tags": ["accordion", "radix"],
+        "tags": [
+          "accordion",
+          "radix"
+        ],
         "colSpan": 2
       }
     },
@@ -5119,7 +6536,10 @@
         }
       ],
       "meta": {
-        "tags": ["accordion", "radix"],
+        "tags": [
+          "accordion",
+          "radix"
+        ],
         "colSpan": 2
       }
     },
@@ -5133,7 +6553,10 @@
         }
       ],
       "meta": {
-        "tags": ["accordion", "radix"],
+        "tags": [
+          "accordion",
+          "radix"
+        ],
         "colSpan": 2
       }
     },
@@ -5147,7 +6570,10 @@
         }
       ],
       "meta": {
-        "tags": ["accordion", "radix"],
+        "tags": [
+          "accordion",
+          "radix"
+        ],
         "colSpan": 2
       }
     },
@@ -5161,7 +6587,10 @@
         }
       ],
       "meta": {
-        "tags": ["accordion", "radix"],
+        "tags": [
+          "accordion",
+          "radix"
+        ],
         "colSpan": 2
       }
     },
@@ -5175,7 +6604,10 @@
         }
       ],
       "meta": {
-        "tags": ["accordion", "radix"],
+        "tags": [
+          "accordion",
+          "radix"
+        ],
         "colSpan": 2
       }
     },
@@ -5189,7 +6621,10 @@
         }
       ],
       "meta": {
-        "tags": ["accordion", "radix"],
+        "tags": [
+          "accordion",
+          "radix"
+        ],
         "colSpan": 2
       }
     },
@@ -5203,7 +6638,10 @@
         }
       ],
       "meta": {
-        "tags": ["accordion", "radix"],
+        "tags": [
+          "accordion",
+          "radix"
+        ],
         "colSpan": 2
       }
     },
@@ -5217,7 +6655,10 @@
         }
       ],
       "meta": {
-        "tags": ["accordion", "radix"],
+        "tags": [
+          "accordion",
+          "radix"
+        ],
         "colSpan": 2
       }
     },
@@ -5231,7 +6672,10 @@
         }
       ],
       "meta": {
-        "tags": ["accordion", "radix"],
+        "tags": [
+          "accordion",
+          "radix"
+        ],
         "colSpan": 2
       }
     },
@@ -5245,7 +6689,10 @@
         }
       ],
       "meta": {
-        "tags": ["accordion", "radix"],
+        "tags": [
+          "accordion",
+          "radix"
+        ],
         "colSpan": 2
       }
     },
@@ -5259,7 +6706,10 @@
         }
       ],
       "meta": {
-        "tags": ["accordion", "radix"],
+        "tags": [
+          "accordion",
+          "radix"
+        ],
         "colSpan": 2
       }
     },
@@ -5273,7 +6723,11 @@
         }
       ],
       "meta": {
-        "tags": ["accordion", "collapsible", "radix"],
+        "tags": [
+          "accordion",
+          "collapsible",
+          "radix"
+        ],
         "colSpan": 2
       }
     },
@@ -5287,7 +6741,11 @@
         }
       ],
       "meta": {
-        "tags": ["accordion", "collapsible", "radix"],
+        "tags": [
+          "accordion",
+          "collapsible",
+          "radix"
+        ],
         "colSpan": 2
       }
     },
@@ -5301,7 +6759,10 @@
         }
       ],
       "meta": {
-        "tags": ["tooltip", "radix"],
+        "tags": [
+          "tooltip",
+          "radix"
+        ],
         "style": 1
       }
     },
@@ -5315,7 +6776,10 @@
         }
       ],
       "meta": {
-        "tags": ["tooltip", "radix"],
+        "tags": [
+          "tooltip",
+          "radix"
+        ],
         "style": 1
       }
     },
@@ -5329,7 +6793,10 @@
         }
       ],
       "meta": {
-        "tags": ["tooltip", "radix"],
+        "tags": [
+          "tooltip",
+          "radix"
+        ],
         "style": 1
       }
     },
@@ -5343,7 +6810,10 @@
         }
       ],
       "meta": {
-        "tags": ["tooltip", "radix"],
+        "tags": [
+          "tooltip",
+          "radix"
+        ],
         "style": 1
       }
     },
@@ -5357,7 +6827,10 @@
         }
       ],
       "meta": {
-        "tags": ["tooltip", "radix"],
+        "tags": [
+          "tooltip",
+          "radix"
+        ],
         "style": 1
       }
     },
@@ -5371,7 +6844,11 @@
         }
       ],
       "meta": {
-        "tags": ["tooltip", "image", "radix"],
+        "tags": [
+          "tooltip",
+          "image",
+          "radix"
+        ],
         "style": 1
       }
     },
@@ -5385,7 +6862,12 @@
         }
       ],
       "meta": {
-        "tags": ["tooltip", "button", "kbd", "radix"],
+        "tags": [
+          "tooltip",
+          "button",
+          "kbd",
+          "radix"
+        ],
         "style": 1
       }
     },
@@ -5399,7 +6881,10 @@
         }
       ],
       "meta": {
-        "tags": ["tooltip", "radix"],
+        "tags": [
+          "tooltip",
+          "radix"
+        ],
         "style": 1
       }
     },
@@ -5413,7 +6898,11 @@
         }
       ],
       "meta": {
-        "tags": ["tooltip", "chart", "radix"],
+        "tags": [
+          "tooltip",
+          "chart",
+          "radix"
+        ],
         "style": 1
       }
     },
@@ -5427,7 +6916,14 @@
         }
       ],
       "meta": {
-        "tags": ["tooltip", "hover card", "user", "avatar", "profile", "radix"],
+        "tags": [
+          "tooltip",
+          "hover card",
+          "user",
+          "avatar",
+          "profile",
+          "radix"
+        ],
         "style": 1
       }
     },
@@ -5441,7 +6937,14 @@
         }
       ],
       "meta": {
-        "tags": ["tooltip", "hover card", "user", "avatar", "profile", "radix"],
+        "tags": [
+          "tooltip",
+          "hover card",
+          "user",
+          "avatar",
+          "profile",
+          "radix"
+        ],
         "style": 1
       }
     },
@@ -5455,7 +6958,12 @@
         }
       ],
       "meta": {
-        "tags": ["tooltip", "hover card", "image", "radix"],
+        "tags": [
+          "tooltip",
+          "hover card",
+          "image",
+          "radix"
+        ],
         "style": 1
       }
     },
@@ -5469,7 +6977,10 @@
         }
       ],
       "meta": {
-        "tags": ["dropdown", "radix"],
+        "tags": [
+          "dropdown",
+          "radix"
+        ],
         "style": 1
       }
     },
@@ -5483,7 +6994,10 @@
         }
       ],
       "meta": {
-        "tags": ["dropdown", "radix"],
+        "tags": [
+          "dropdown",
+          "radix"
+        ],
         "style": 1
       }
     },
@@ -5497,7 +7011,10 @@
         }
       ],
       "meta": {
-        "tags": ["dropdown", "radix"],
+        "tags": [
+          "dropdown",
+          "radix"
+        ],
         "style": 1
       }
     },
@@ -5511,7 +7028,10 @@
         }
       ],
       "meta": {
-        "tags": ["dropdown", "radix"],
+        "tags": [
+          "dropdown",
+          "radix"
+        ],
         "style": 1
       }
     },
@@ -5525,7 +7045,10 @@
         }
       ],
       "meta": {
-        "tags": ["dropdown", "radix"],
+        "tags": [
+          "dropdown",
+          "radix"
+        ],
         "style": 1
       }
     },
@@ -5539,7 +7062,11 @@
         }
       ],
       "meta": {
-        "tags": ["dropdown", "checkbox", "radix"],
+        "tags": [
+          "dropdown",
+          "checkbox",
+          "radix"
+        ],
         "style": 1
       }
     },
@@ -5553,7 +7080,11 @@
         }
       ],
       "meta": {
-        "tags": ["dropdown", "radio", "radix"],
+        "tags": [
+          "dropdown",
+          "radio",
+          "radix"
+        ],
         "style": 1
       }
     },
@@ -5567,7 +7098,12 @@
         }
       ],
       "meta": {
-        "tags": ["dropdown", "kbd", "delete", "radix"],
+        "tags": [
+          "dropdown",
+          "kbd",
+          "delete",
+          "radix"
+        ],
         "style": 1
       }
     },
@@ -5581,7 +7117,13 @@
         }
       ],
       "meta": {
-        "tags": ["dropdown", "checkbox", "radio", "delete", "radix"],
+        "tags": [
+          "dropdown",
+          "checkbox",
+          "radio",
+          "delete",
+          "radix"
+        ],
         "style": 1
       }
     },
@@ -5595,7 +7137,12 @@
         }
       ],
       "meta": {
-        "tags": ["dropdown", "user", "profile", "radix"],
+        "tags": [
+          "dropdown",
+          "user",
+          "profile",
+          "radix"
+        ],
         "style": 1
       }
     },
@@ -5609,7 +7156,13 @@
         }
       ],
       "meta": {
-        "tags": ["dropdown", "user", "profile", "avatar", "radix"],
+        "tags": [
+          "dropdown",
+          "user",
+          "profile",
+          "avatar",
+          "radix"
+        ],
         "style": 1
       }
     },
@@ -5623,7 +7176,13 @@
         }
       ],
       "meta": {
-        "tags": ["dropdown", "user", "avatar", "profile", "radix"],
+        "tags": [
+          "dropdown",
+          "user",
+          "avatar",
+          "profile",
+          "radix"
+        ],
         "style": 1
       }
     },
@@ -5637,7 +7196,11 @@
         }
       ],
       "meta": {
-        "tags": ["dropdown", "info", "radix"],
+        "tags": [
+          "dropdown",
+          "info",
+          "radix"
+        ],
         "style": 1
       }
     },
@@ -5651,7 +7214,11 @@
         }
       ],
       "meta": {
-        "tags": ["dropdown", "text editor", "radix"],
+        "tags": [
+          "dropdown",
+          "text editor",
+          "radix"
+        ],
         "style": 1
       }
     },
@@ -5665,7 +7232,11 @@
         }
       ],
       "meta": {
-        "tags": ["dropdown", "darkmode", "radix"],
+        "tags": [
+          "dropdown",
+          "darkmode",
+          "radix"
+        ],
         "style": 1
       }
     },
@@ -5679,7 +7250,11 @@
         }
       ],
       "meta": {
-        "tags": ["popover", "filter", "radix"],
+        "tags": [
+          "popover",
+          "filter",
+          "radix"
+        ],
         "style": 1
       }
     },
@@ -5693,7 +7268,11 @@
         }
       ],
       "meta": {
-        "tags": ["popover", "notification", "radix"],
+        "tags": [
+          "popover",
+          "notification",
+          "radix"
+        ],
         "style": 1
       }
     },
@@ -5707,7 +7286,12 @@
         }
       ],
       "meta": {
-        "tags": ["popover", "notification", "user", "radix"],
+        "tags": [
+          "popover",
+          "notification",
+          "user",
+          "radix"
+        ],
         "style": 1
       }
     },
@@ -5721,7 +7305,11 @@
         }
       ],
       "meta": {
-        "tags": ["popover", "tooltip", "radix"],
+        "tags": [
+          "popover",
+          "tooltip",
+          "radix"
+        ],
         "style": 1
       }
     },
@@ -5735,7 +7323,11 @@
         }
       ],
       "meta": {
-        "tags": ["popover", "tooltip", "radix"],
+        "tags": [
+          "popover",
+          "tooltip",
+          "radix"
+        ],
         "style": 1
       }
     },
@@ -5749,7 +7341,11 @@
         }
       ],
       "meta": {
-        "tags": ["popover", "tooltip", "radix"],
+        "tags": [
+          "popover",
+          "tooltip",
+          "radix"
+        ],
         "style": 1
       }
     },
@@ -5763,7 +7359,13 @@
         }
       ],
       "meta": {
-        "tags": ["popover", "share", "social", "copy", "radix"],
+        "tags": [
+          "popover",
+          "share",
+          "social",
+          "copy",
+          "radix"
+        ],
         "style": 1
       }
     },
@@ -5777,7 +7379,12 @@
         }
       ],
       "meta": {
-        "tags": ["popover", "feedback", "form", "radix"],
+        "tags": [
+          "popover",
+          "feedback",
+          "form",
+          "radix"
+        ],
         "style": 1
       }
     },
@@ -5791,7 +7398,11 @@
         }
       ],
       "meta": {
-        "tags": ["popover", "tour", "radix"],
+        "tags": [
+          "popover",
+          "tour",
+          "radix"
+        ],
         "style": 1
       }
     },
@@ -5805,7 +7416,11 @@
         }
       ],
       "meta": {
-        "tags": ["avatar", "user", "profile"],
+        "tags": [
+          "avatar",
+          "user",
+          "profile"
+        ],
         "style": 1
       }
     },
@@ -5819,7 +7434,11 @@
         }
       ],
       "meta": {
-        "tags": ["avatar", "user", "profile"],
+        "tags": [
+          "avatar",
+          "user",
+          "profile"
+        ],
         "style": 1
       }
     },
@@ -5833,7 +7452,11 @@
         }
       ],
       "meta": {
-        "tags": ["avatar", "user", "profile"],
+        "tags": [
+          "avatar",
+          "user",
+          "profile"
+        ],
         "style": 1
       }
     },
@@ -5847,7 +7470,11 @@
         }
       ],
       "meta": {
-        "tags": ["avatar", "user", "profile"],
+        "tags": [
+          "avatar",
+          "user",
+          "profile"
+        ],
         "style": 1
       }
     },
@@ -5861,7 +7488,12 @@
         }
       ],
       "meta": {
-        "tags": ["avatar", "user", "profile", "status"],
+        "tags": [
+          "avatar",
+          "user",
+          "profile",
+          "status"
+        ],
         "style": 1
       }
     },
@@ -5875,7 +7507,12 @@
         }
       ],
       "meta": {
-        "tags": ["avatar", "user", "profile", "status"],
+        "tags": [
+          "avatar",
+          "user",
+          "profile",
+          "status"
+        ],
         "style": 1
       }
     },
@@ -5889,7 +7526,12 @@
         }
       ],
       "meta": {
-        "tags": ["avatar", "user", "profile", "status"],
+        "tags": [
+          "avatar",
+          "user",
+          "profile",
+          "status"
+        ],
         "style": 1
       }
     },
@@ -5903,7 +7545,13 @@
         }
       ],
       "meta": {
-        "tags": ["avatar", "user", "profile", "badge", "chip"],
+        "tags": [
+          "avatar",
+          "user",
+          "profile",
+          "badge",
+          "chip"
+        ],
         "style": 1
       }
     },
@@ -5917,7 +7565,13 @@
         }
       ],
       "meta": {
-        "tags": ["avatar", "user", "profile", "badge", "chip"],
+        "tags": [
+          "avatar",
+          "user",
+          "profile",
+          "badge",
+          "chip"
+        ],
         "style": 1
       }
     },
@@ -5931,7 +7585,13 @@
         }
       ],
       "meta": {
-        "tags": ["avatar", "user", "profile", "badge", "chip"],
+        "tags": [
+          "avatar",
+          "user",
+          "profile",
+          "badge",
+          "chip"
+        ],
         "style": 1
       }
     },
@@ -5945,7 +7605,11 @@
         }
       ],
       "meta": {
-        "tags": ["avatar", "user", "profile"],
+        "tags": [
+          "avatar",
+          "user",
+          "profile"
+        ],
         "style": 1
       }
     },
@@ -5959,7 +7623,10 @@
         }
       ],
       "meta": {
-        "tags": ["avatar", "avatar group"],
+        "tags": [
+          "avatar",
+          "avatar group"
+        ],
         "style": 1
       }
     },
@@ -5973,7 +7640,10 @@
         }
       ],
       "meta": {
-        "tags": ["avatar", "avatar group"],
+        "tags": [
+          "avatar",
+          "avatar group"
+        ],
         "style": 1
       }
     },
@@ -5987,7 +7657,10 @@
         }
       ],
       "meta": {
-        "tags": ["avatar", "avatar group"],
+        "tags": [
+          "avatar",
+          "avatar group"
+        ],
         "style": 1
       }
     },
@@ -6001,7 +7674,10 @@
         }
       ],
       "meta": {
-        "tags": ["avatar", "avatar group"],
+        "tags": [
+          "avatar",
+          "avatar group"
+        ],
         "style": 1
       }
     },
@@ -6015,7 +7691,10 @@
         }
       ],
       "meta": {
-        "tags": ["avatar", "avatar group"],
+        "tags": [
+          "avatar",
+          "avatar group"
+        ],
         "style": 1
       }
     },
@@ -6029,7 +7708,10 @@
         }
       ],
       "meta": {
-        "tags": ["avatar", "avatar group"],
+        "tags": [
+          "avatar",
+          "avatar group"
+        ],
         "style": 1
       }
     },
@@ -6043,7 +7725,10 @@
         }
       ],
       "meta": {
-        "tags": ["avatar", "avatar group"],
+        "tags": [
+          "avatar",
+          "avatar group"
+        ],
         "style": 1
       }
     },
@@ -6057,7 +7742,10 @@
         }
       ],
       "meta": {
-        "tags": ["avatar", "avatar group"],
+        "tags": [
+          "avatar",
+          "avatar group"
+        ],
         "style": 1
       }
     },
@@ -6071,7 +7759,10 @@
         }
       ],
       "meta": {
-        "tags": ["avatar", "avatar group"],
+        "tags": [
+          "avatar",
+          "avatar group"
+        ],
         "style": 1
       }
     },
@@ -6085,7 +7776,10 @@
         }
       ],
       "meta": {
-        "tags": ["avatar", "avatar group"],
+        "tags": [
+          "avatar",
+          "avatar group"
+        ],
         "style": 1
       }
     },
@@ -6099,7 +7793,10 @@
         }
       ],
       "meta": {
-        "tags": ["avatar", "avatar group"],
+        "tags": [
+          "avatar",
+          "avatar group"
+        ],
         "style": 1
       }
     },
@@ -6113,7 +7810,10 @@
         }
       ],
       "meta": {
-        "tags": ["avatar", "avatar group"],
+        "tags": [
+          "avatar",
+          "avatar group"
+        ],
         "style": 1
       }
     },
@@ -6127,7 +7827,10 @@
         }
       ],
       "meta": {
-        "tags": ["badge", "chip"],
+        "tags": [
+          "badge",
+          "chip"
+        ],
         "style": 1
       }
     },
@@ -6141,7 +7844,10 @@
         }
       ],
       "meta": {
-        "tags": ["badge", "chip"],
+        "tags": [
+          "badge",
+          "chip"
+        ],
         "style": 1
       }
     },
@@ -6155,7 +7861,10 @@
         }
       ],
       "meta": {
-        "tags": ["badge", "chip"],
+        "tags": [
+          "badge",
+          "chip"
+        ],
         "style": 1
       }
     },
@@ -6169,7 +7878,11 @@
         }
       ],
       "meta": {
-        "tags": ["badge", "chip", "counter"],
+        "tags": [
+          "badge",
+          "chip",
+          "counter"
+        ],
         "style": 1
       }
     },
@@ -6183,7 +7896,10 @@
         }
       ],
       "meta": {
-        "tags": ["badge", "chip"],
+        "tags": [
+          "badge",
+          "chip"
+        ],
         "style": 1
       }
     },
@@ -6197,7 +7913,11 @@
         }
       ],
       "meta": {
-        "tags": ["badge", "chip", "counter"],
+        "tags": [
+          "badge",
+          "chip",
+          "counter"
+        ],
         "style": 1
       }
     },
@@ -6211,7 +7931,11 @@
         }
       ],
       "meta": {
-        "tags": ["badge", "chip", "status"],
+        "tags": [
+          "badge",
+          "chip",
+          "status"
+        ],
         "style": 1
       }
     },
@@ -6225,7 +7949,11 @@
         }
       ],
       "meta": {
-        "tags": ["badge", "chip", "status"],
+        "tags": [
+          "badge",
+          "chip",
+          "status"
+        ],
         "style": 1
       }
     },
@@ -6239,7 +7967,11 @@
         }
       ],
       "meta": {
-        "tags": ["badge", "chip", "status"],
+        "tags": [
+          "badge",
+          "chip",
+          "status"
+        ],
         "style": 1
       }
     },
@@ -6253,7 +7985,11 @@
         }
       ],
       "meta": {
-        "tags": ["badge", "chip", "status"],
+        "tags": [
+          "badge",
+          "chip",
+          "status"
+        ],
         "style": 1
       }
     },
@@ -6267,7 +8003,11 @@
         }
       ],
       "meta": {
-        "tags": ["badge", "chip", "checkbox"],
+        "tags": [
+          "badge",
+          "chip",
+          "checkbox"
+        ],
         "style": 1
       }
     },
@@ -6281,7 +8021,10 @@
         }
       ],
       "meta": {
-        "tags": ["badge", "chip"],
+        "tags": [
+          "badge",
+          "chip"
+        ],
         "style": 1
       }
     },
@@ -6295,7 +8038,11 @@
         }
       ],
       "meta": {
-        "tags": ["badge", "chip", "tag"],
+        "tags": [
+          "badge",
+          "chip",
+          "tag"
+        ],
         "style": 1
       }
     },
@@ -6309,7 +8056,10 @@
         }
       ],
       "meta": {
-        "tags": ["tabs", "radix"],
+        "tags": [
+          "tabs",
+          "radix"
+        ],
         "colSpan": 2,
         "style": 2
       }
@@ -6324,7 +8074,10 @@
         }
       ],
       "meta": {
-        "tags": ["tabs", "radix"],
+        "tags": [
+          "tabs",
+          "radix"
+        ],
         "colSpan": 2,
         "style": 2
       }
@@ -6339,7 +8092,10 @@
         }
       ],
       "meta": {
-        "tags": ["tabs", "radix"],
+        "tags": [
+          "tabs",
+          "radix"
+        ],
         "colSpan": 2,
         "style": 2
       }
@@ -6354,7 +8110,10 @@
         }
       ],
       "meta": {
-        "tags": ["tabs", "radix"],
+        "tags": [
+          "tabs",
+          "radix"
+        ],
         "colSpan": 2,
         "style": 2
       }
@@ -6369,7 +8128,10 @@
         }
       ],
       "meta": {
-        "tags": ["tabs", "radix"],
+        "tags": [
+          "tabs",
+          "radix"
+        ],
         "colSpan": 2,
         "style": 2
       }
@@ -6384,7 +8146,10 @@
         }
       ],
       "meta": {
-        "tags": ["tabs", "radix"],
+        "tags": [
+          "tabs",
+          "radix"
+        ],
         "colSpan": 2,
         "style": 2
       }
@@ -6399,7 +8164,10 @@
         }
       ],
       "meta": {
-        "tags": ["tabs", "radix"],
+        "tags": [
+          "tabs",
+          "radix"
+        ],
         "colSpan": 2,
         "style": 2
       }
@@ -6414,7 +8182,10 @@
         }
       ],
       "meta": {
-        "tags": ["tabs", "radix"],
+        "tags": [
+          "tabs",
+          "radix"
+        ],
         "colSpan": 2,
         "style": 2
       }
@@ -6429,7 +8200,10 @@
         }
       ],
       "meta": {
-        "tags": ["tabs", "radix"],
+        "tags": [
+          "tabs",
+          "radix"
+        ],
         "colSpan": 2,
         "style": 2
       }
@@ -6444,7 +8218,10 @@
         }
       ],
       "meta": {
-        "tags": ["tabs", "radix"],
+        "tags": [
+          "tabs",
+          "radix"
+        ],
         "colSpan": 2,
         "style": 2
       }
@@ -6459,7 +8236,10 @@
         }
       ],
       "meta": {
-        "tags": ["tabs", "radix"],
+        "tags": [
+          "tabs",
+          "radix"
+        ],
         "colSpan": 2,
         "style": 2
       }
@@ -6474,7 +8254,10 @@
         }
       ],
       "meta": {
-        "tags": ["tabs", "radix"],
+        "tags": [
+          "tabs",
+          "radix"
+        ],
         "colSpan": 2,
         "style": 2
       }
@@ -6489,7 +8272,10 @@
         }
       ],
       "meta": {
-        "tags": ["tabs", "radix"],
+        "tags": [
+          "tabs",
+          "radix"
+        ],
         "colSpan": 2,
         "style": 2
       }
@@ -6504,7 +8290,10 @@
         }
       ],
       "meta": {
-        "tags": ["tabs", "radix"],
+        "tags": [
+          "tabs",
+          "radix"
+        ],
         "colSpan": 2,
         "style": 2
       }
@@ -6519,7 +8308,10 @@
         }
       ],
       "meta": {
-        "tags": ["tabs", "radix"],
+        "tags": [
+          "tabs",
+          "radix"
+        ],
         "colSpan": 2,
         "style": 2
       }
@@ -6534,7 +8326,10 @@
         }
       ],
       "meta": {
-        "tags": ["tabs", "radix"],
+        "tags": [
+          "tabs",
+          "radix"
+        ],
         "colSpan": 2,
         "style": 2
       }
@@ -6549,7 +8344,11 @@
         }
       ],
       "meta": {
-        "tags": ["tabs", "vertical tabs", "radix"],
+        "tags": [
+          "tabs",
+          "vertical tabs",
+          "radix"
+        ],
         "colSpan": 2,
         "style": 2
       }
@@ -6564,7 +8363,11 @@
         }
       ],
       "meta": {
-        "tags": ["tabs", "vertical tabs", "radix"],
+        "tags": [
+          "tabs",
+          "vertical tabs",
+          "radix"
+        ],
         "colSpan": 2,
         "style": 2
       }
@@ -6579,7 +8382,11 @@
         }
       ],
       "meta": {
-        "tags": ["tabs", "vertical tabs", "radix"],
+        "tags": [
+          "tabs",
+          "vertical tabs",
+          "radix"
+        ],
         "colSpan": 2,
         "style": 2
       }
@@ -6594,7 +8401,11 @@
         }
       ],
       "meta": {
-        "tags": ["tabs", "vertical tabs", "radix"],
+        "tags": [
+          "tabs",
+          "vertical tabs",
+          "radix"
+        ],
         "colSpan": 2,
         "style": 2
       }
@@ -6609,7 +8420,10 @@
         }
       ],
       "meta": {
-        "tags": ["breadcrumb", "radix"],
+        "tags": [
+          "breadcrumb",
+          "radix"
+        ],
         "colSpan": 2,
         "style": 1
       }
@@ -6624,7 +8438,11 @@
         }
       ],
       "meta": {
-        "tags": ["breadcrumb", "dropdown", "radix"],
+        "tags": [
+          "breadcrumb",
+          "dropdown",
+          "radix"
+        ],
         "colSpan": 2,
         "style": 1
       }
@@ -6639,7 +8457,10 @@
         }
       ],
       "meta": {
-        "tags": ["breadcrumb", "radix"],
+        "tags": [
+          "breadcrumb",
+          "radix"
+        ],
         "colSpan": 2,
         "style": 1
       }
@@ -6654,7 +8475,10 @@
         }
       ],
       "meta": {
-        "tags": ["breadcrumb", "radix"],
+        "tags": [
+          "breadcrumb",
+          "radix"
+        ],
         "colSpan": 2,
         "style": 1
       }
@@ -6669,7 +8493,10 @@
         }
       ],
       "meta": {
-        "tags": ["breadcrumb", "radix"],
+        "tags": [
+          "breadcrumb",
+          "radix"
+        ],
         "colSpan": 2,
         "style": 1
       }
@@ -6684,7 +8511,10 @@
         }
       ],
       "meta": {
-        "tags": ["breadcrumb", "radix"],
+        "tags": [
+          "breadcrumb",
+          "radix"
+        ],
         "colSpan": 2,
         "style": 1
       }
@@ -6699,7 +8529,10 @@
         }
       ],
       "meta": {
-        "tags": ["breadcrumb", "radix"],
+        "tags": [
+          "breadcrumb",
+          "radix"
+        ],
         "colSpan": 2,
         "style": 1
       }
@@ -6714,7 +8547,11 @@
         }
       ],
       "meta": {
-        "tags": ["breadcrumb", "select", "radix"],
+        "tags": [
+          "breadcrumb",
+          "select",
+          "radix"
+        ],
         "colSpan": 2,
         "style": 1
       }
@@ -6729,7 +8566,9 @@
         }
       ],
       "meta": {
-        "tags": ["pagination"],
+        "tags": [
+          "pagination"
+        ],
         "colSpan": 2
       }
     },
@@ -6743,7 +8582,9 @@
         }
       ],
       "meta": {
-        "tags": ["pagination"],
+        "tags": [
+          "pagination"
+        ],
         "colSpan": 2
       }
     },
@@ -6757,7 +8598,9 @@
         }
       ],
       "meta": {
-        "tags": ["pagination"],
+        "tags": [
+          "pagination"
+        ],
         "colSpan": 2
       }
     },
@@ -6771,7 +8614,9 @@
         }
       ],
       "meta": {
-        "tags": ["pagination"],
+        "tags": [
+          "pagination"
+        ],
         "colSpan": 2
       }
     },
@@ -6785,7 +8630,9 @@
         }
       ],
       "meta": {
-        "tags": ["pagination"],
+        "tags": [
+          "pagination"
+        ],
         "colSpan": 2
       }
     },
@@ -6799,7 +8646,9 @@
         }
       ],
       "meta": {
-        "tags": ["pagination"],
+        "tags": [
+          "pagination"
+        ],
         "colSpan": 2
       }
     },
@@ -6813,7 +8662,9 @@
         }
       ],
       "meta": {
-        "tags": ["pagination"],
+        "tags": [
+          "pagination"
+        ],
         "colSpan": 2
       }
     },
@@ -6827,7 +8678,9 @@
         }
       ],
       "meta": {
-        "tags": ["pagination"],
+        "tags": [
+          "pagination"
+        ],
         "colSpan": 2
       }
     },
@@ -6841,7 +8694,9 @@
         }
       ],
       "meta": {
-        "tags": ["pagination"],
+        "tags": [
+          "pagination"
+        ],
         "colSpan": 2
       }
     },
@@ -6855,7 +8710,11 @@
         }
       ],
       "meta": {
-        "tags": ["pagination", "select", "radix"],
+        "tags": [
+          "pagination",
+          "select",
+          "radix"
+        ],
         "colSpan": 2
       }
     },
@@ -6869,7 +8728,11 @@
         }
       ],
       "meta": {
-        "tags": ["pagination", "select", "radix"],
+        "tags": [
+          "pagination",
+          "select",
+          "radix"
+        ],
         "colSpan": 2
       }
     },
@@ -6883,7 +8746,10 @@
         }
       ],
       "meta": {
-        "tags": ["pagination", "input"],
+        "tags": [
+          "pagination",
+          "input"
+        ],
         "colSpan": 2
       }
     },
@@ -6897,7 +8763,9 @@
         }
       ],
       "meta": {
-        "tags": ["table"],
+        "tags": [
+          "table"
+        ],
         "colSpan": 3
       }
     },
@@ -6911,7 +8779,11 @@
         }
       ],
       "meta": {
-        "tags": ["table", "user", "avatar"],
+        "tags": [
+          "table",
+          "user",
+          "avatar"
+        ],
         "colSpan": 3
       }
     },
@@ -6925,7 +8797,9 @@
         }
       ],
       "meta": {
-        "tags": ["table"],
+        "tags": [
+          "table"
+        ],
         "colSpan": 3
       }
     },
@@ -6939,7 +8813,9 @@
         }
       ],
       "meta": {
-        "tags": ["table"],
+        "tags": [
+          "table"
+        ],
         "colSpan": 3
       }
     },
@@ -6953,7 +8829,9 @@
         }
       ],
       "meta": {
-        "tags": ["table"],
+        "tags": [
+          "table"
+        ],
         "colSpan": 3
       }
     },
@@ -6967,7 +8845,9 @@
         }
       ],
       "meta": {
-        "tags": ["table"],
+        "tags": [
+          "table"
+        ],
         "colSpan": 3
       }
     },
@@ -6981,7 +8861,10 @@
         }
       ],
       "meta": {
-        "tags": ["table", "checkbox"],
+        "tags": [
+          "table",
+          "checkbox"
+        ],
         "colSpan": 3
       }
     },
@@ -6995,7 +8878,11 @@
         }
       ],
       "meta": {
-        "tags": ["table", "checkbox", "card"],
+        "tags": [
+          "table",
+          "checkbox",
+          "card"
+        ],
         "colSpan": 3
       }
     },
@@ -7009,7 +8896,10 @@
         }
       ],
       "meta": {
-        "tags": ["table", "vertical table"],
+        "tags": [
+          "table",
+          "vertical table"
+        ],
         "colSpan": 3
       }
     },
@@ -7023,7 +8913,10 @@
         }
       ],
       "meta": {
-        "tags": ["table", "sticky"],
+        "tags": [
+          "table",
+          "sticky"
+        ],
         "colSpan": 3
       }
     },
@@ -7037,7 +8930,9 @@
         }
       ],
       "meta": {
-        "tags": ["table"],
+        "tags": [
+          "table"
+        ],
         "colSpan": 3
       }
     },
@@ -7051,7 +8946,14 @@
         }
       ],
       "meta": {
-        "tags": ["table", "tanstack", "checkbox", "badge", "chip", "flag"],
+        "tags": [
+          "table",
+          "tanstack",
+          "checkbox",
+          "badge",
+          "chip",
+          "flag"
+        ],
         "colSpan": 3
       }
     },
@@ -7089,7 +8991,13 @@
         }
       ],
       "meta": {
-        "tags": ["table", "tanstack", "flag", "sort", "resize"],
+        "tags": [
+          "table",
+          "tanstack",
+          "flag",
+          "sort",
+          "resize"
+        ],
         "colSpan": 3
       }
     },
@@ -7103,7 +9011,13 @@
         }
       ],
       "meta": {
-        "tags": ["table", "tanstack", "flag", "sticky", "resize"],
+        "tags": [
+          "table",
+          "tanstack",
+          "flag",
+          "sticky",
+          "resize"
+        ],
         "colSpan": 3
       }
     },
@@ -7117,7 +9031,13 @@
         }
       ],
       "meta": {
-        "tags": ["table", "tanstack", "flag", "sort", "drag and drop"],
+        "tags": [
+          "table",
+          "tanstack",
+          "flag",
+          "sort",
+          "drag and drop"
+        ],
         "colSpan": 3
       }
     },
@@ -7131,7 +9051,15 @@
         }
       ],
       "meta": {
-        "tags": ["table", "tanstack", "checkbox", "collapsible", "flag", "badge", "chip"],
+        "tags": [
+          "table",
+          "tanstack",
+          "checkbox",
+          "collapsible",
+          "flag",
+          "badge",
+          "chip"
+        ],
         "colSpan": 3
       }
     },
@@ -7145,7 +9073,16 @@
         }
       ],
       "meta": {
-        "tags": ["table", "tanstack", "checkbox", "sort", "flag", "badge", "chip", "pagination"],
+        "tags": [
+          "table",
+          "tanstack",
+          "checkbox",
+          "sort",
+          "flag",
+          "badge",
+          "chip",
+          "pagination"
+        ],
         "colSpan": 3
       }
     },
@@ -7159,7 +9096,16 @@
         }
       ],
       "meta": {
-        "tags": ["table", "tanstack", "checkbox", "sort", "flag", "badge", "chip", "pagination"],
+        "tags": [
+          "table",
+          "tanstack",
+          "checkbox",
+          "sort",
+          "flag",
+          "badge",
+          "chip",
+          "pagination"
+        ],
         "colSpan": 3
       }
     },
@@ -7198,7 +9144,11 @@
         }
       ],
       "meta": {
-        "tags": ["input", "label", "range"]
+        "tags": [
+          "input",
+          "label",
+          "range"
+        ]
       }
     },
     {
@@ -7211,7 +9161,11 @@
         }
       ],
       "meta": {
-        "tags": ["calendar", "date", "react aria"],
+        "tags": [
+          "calendar",
+          "date",
+          "react aria"
+        ],
         "style": 1
       }
     },
@@ -7225,7 +9179,12 @@
         }
       ],
       "meta": {
-        "tags": ["calendar", "range calendar", "date", "react aria"],
+        "tags": [
+          "calendar",
+          "range calendar",
+          "date",
+          "react aria"
+        ],
         "style": 1
       }
     },
@@ -7239,7 +9198,13 @@
         }
       ],
       "meta": {
-        "tags": ["calendar", "range calendar", "date", "disabled", "react aria"],
+        "tags": [
+          "calendar",
+          "range calendar",
+          "date",
+          "disabled",
+          "react aria"
+        ],
         "style": 1
       }
     },
@@ -7253,7 +9218,11 @@
         }
       ],
       "meta": {
-        "tags": ["calendar", "date", "react daypicker"],
+        "tags": [
+          "calendar",
+          "date",
+          "react daypicker"
+        ],
         "style": 1
       }
     },
@@ -7267,7 +9236,12 @@
         }
       ],
       "meta": {
-        "tags": ["calendar", "range calendar", "date", "react daypicker"],
+        "tags": [
+          "calendar",
+          "range calendar",
+          "date",
+          "react daypicker"
+        ],
         "style": 1
       }
     },
@@ -7281,7 +9255,13 @@
         }
       ],
       "meta": {
-        "tags": ["calendar", "range calendar", "date", "disabled", "react daypicker"],
+        "tags": [
+          "calendar",
+          "range calendar",
+          "date",
+          "disabled",
+          "react daypicker"
+        ],
         "style": 1
       }
     },
@@ -7295,7 +9275,11 @@
         }
       ],
       "meta": {
-        "tags": ["calendar", "date", "react daypicker"],
+        "tags": [
+          "calendar",
+          "date",
+          "react daypicker"
+        ],
         "style": 1
       }
     },
@@ -7309,7 +9293,11 @@
         }
       ],
       "meta": {
-        "tags": ["calendar", "date", "react daypicker"],
+        "tags": [
+          "calendar",
+          "date",
+          "react daypicker"
+        ],
         "style": 1
       }
     },
@@ -7323,7 +9311,12 @@
         }
       ],
       "meta": {
-        "tags": ["calendar", "range calendar", "date", "react daypicker"],
+        "tags": [
+          "calendar",
+          "range calendar",
+          "date",
+          "react daypicker"
+        ],
         "style": 1
       }
     },
@@ -7337,7 +9330,11 @@
         }
       ],
       "meta": {
-        "tags": ["calendar", "date", "react daypicker"],
+        "tags": [
+          "calendar",
+          "date",
+          "react daypicker"
+        ],
         "style": 1
       }
     },
@@ -7351,7 +9348,11 @@
         }
       ],
       "meta": {
-        "tags": ["calendar", "date", "react daypicker"],
+        "tags": [
+          "calendar",
+          "date",
+          "react daypicker"
+        ],
         "style": 1
       }
     },
@@ -7365,7 +9366,11 @@
         }
       ],
       "meta": {
-        "tags": ["calendar", "date", "react daypicker"],
+        "tags": [
+          "calendar",
+          "date",
+          "react daypicker"
+        ],
         "style": 1
       }
     },
@@ -7379,7 +9384,12 @@
         }
       ],
       "meta": {
-        "tags": ["calendar", "date", "week", "react daypicker"],
+        "tags": [
+          "calendar",
+          "date",
+          "week",
+          "react daypicker"
+        ],
         "style": 1
       }
     },
@@ -7393,7 +9403,12 @@
         }
       ],
       "meta": {
-        "tags": ["calendar", "date", "button", "react daypicker"],
+        "tags": [
+          "calendar",
+          "date",
+          "button",
+          "react daypicker"
+        ],
         "style": 1
       }
     },
@@ -7407,7 +9422,12 @@
         }
       ],
       "meta": {
-        "tags": ["calendar", "date", "button", "react daypicker"],
+        "tags": [
+          "calendar",
+          "date",
+          "button",
+          "react daypicker"
+        ],
         "style": 1
       }
     },
@@ -7421,7 +9441,12 @@
         }
       ],
       "meta": {
-        "tags": ["calendar", "date", "input", "react daypicker"],
+        "tags": [
+          "calendar",
+          "date",
+          "input",
+          "react daypicker"
+        ],
         "style": 1
       }
     },
@@ -7435,7 +9460,13 @@
         }
       ],
       "meta": {
-        "tags": ["calendar", "date", "input", "time", "react daypicker"],
+        "tags": [
+          "calendar",
+          "date",
+          "input",
+          "time",
+          "react daypicker"
+        ],
         "style": 1
       }
     },
@@ -7449,7 +9480,13 @@
         }
       ],
       "meta": {
-        "tags": ["calendar", "date", "collapsible", "react daypicker", "radix"],
+        "tags": [
+          "calendar",
+          "date",
+          "collapsible",
+          "react daypicker",
+          "radix"
+        ],
         "style": 1
       }
     },
@@ -7463,7 +9500,13 @@
         }
       ],
       "meta": {
-        "tags": ["calendar", "date", "time", "button", "react daypicker"],
+        "tags": [
+          "calendar",
+          "date",
+          "time",
+          "button",
+          "react daypicker"
+        ],
         "colSpan": 3,
         "style": 1
       }
@@ -7478,7 +9521,12 @@
         }
       ],
       "meta": {
-        "tags": ["calendar", "date", "button", "react daypicker"],
+        "tags": [
+          "calendar",
+          "date",
+          "button",
+          "react daypicker"
+        ],
         "colSpan": 3,
         "style": 1
       }
@@ -7493,7 +9541,13 @@
         }
       ],
       "meta": {
-        "tags": ["calendar", "range calendar", "date", "button", "react daypicker"],
+        "tags": [
+          "calendar",
+          "range calendar",
+          "date",
+          "button",
+          "react daypicker"
+        ],
         "colSpan": 3,
         "style": 1
       }
@@ -7508,7 +9562,12 @@
         }
       ],
       "meta": {
-        "tags": ["calendar", "range calendar", "date", "react daypicker"],
+        "tags": [
+          "calendar",
+          "range calendar",
+          "date",
+          "react daypicker"
+        ],
         "colSpan": 3,
         "style": 1
       }
@@ -7523,7 +9582,12 @@
         }
       ],
       "meta": {
-        "tags": ["calendar", "range calendar", "date", "react daypicker"],
+        "tags": [
+          "calendar",
+          "range calendar",
+          "date",
+          "react daypicker"
+        ],
         "colSpan": 3,
         "style": 1
       }
@@ -7538,7 +9602,11 @@
         }
       ],
       "meta": {
-        "tags": ["calendar", "date", "react daypicker"],
+        "tags": [
+          "calendar",
+          "date",
+          "react daypicker"
+        ],
         "colSpan": 3,
         "style": 1
       }
@@ -7553,7 +9621,13 @@
         }
       ],
       "meta": {
-        "tags": ["calendar", "date", "button", "picker", "react daypicker"]
+        "tags": [
+          "calendar",
+          "date",
+          "button",
+          "picker",
+          "react daypicker"
+        ]
       }
     },
     {
@@ -7566,7 +9640,13 @@
         }
       ],
       "meta": {
-        "tags": ["calendar", "date", "button", "picker", "react daypicker"]
+        "tags": [
+          "calendar",
+          "date",
+          "button",
+          "picker",
+          "react daypicker"
+        ]
       }
     },
     {
@@ -7579,7 +9659,9 @@
         }
       ],
       "meta": {
-        "tags": ["stepper"],
+        "tags": [
+          "stepper"
+        ],
         "colSpan": 3
       }
     },
@@ -7593,7 +9675,9 @@
         }
       ],
       "meta": {
-        "tags": ["stepper"],
+        "tags": [
+          "stepper"
+        ],
         "colSpan": 3
       }
     },
@@ -7607,7 +9691,9 @@
         }
       ],
       "meta": {
-        "tags": ["stepper"],
+        "tags": [
+          "stepper"
+        ],
         "colSpan": 3
       }
     },
@@ -7621,7 +9707,9 @@
         }
       ],
       "meta": {
-        "tags": ["stepper"],
+        "tags": [
+          "stepper"
+        ],
         "colSpan": 3
       }
     },
@@ -7635,7 +9723,9 @@
         }
       ],
       "meta": {
-        "tags": ["stepper"],
+        "tags": [
+          "stepper"
+        ],
         "colSpan": 3
       }
     },
@@ -7649,7 +9739,9 @@
         }
       ],
       "meta": {
-        "tags": ["stepper"],
+        "tags": [
+          "stepper"
+        ],
         "colSpan": 3
       }
     },
@@ -7663,7 +9755,9 @@
         }
       ],
       "meta": {
-        "tags": ["stepper"],
+        "tags": [
+          "stepper"
+        ],
         "colSpan": 3
       }
     },
@@ -7677,7 +9771,9 @@
         }
       ],
       "meta": {
-        "tags": ["stepper"],
+        "tags": [
+          "stepper"
+        ],
         "colSpan": 3
       }
     },
@@ -7691,7 +9787,9 @@
         }
       ],
       "meta": {
-        "tags": ["stepper"],
+        "tags": [
+          "stepper"
+        ],
         "colSpan": 3
       }
     },
@@ -7705,7 +9803,9 @@
         }
       ],
       "meta": {
-        "tags": ["stepper"],
+        "tags": [
+          "stepper"
+        ],
         "colSpan": 3
       }
     },
@@ -7719,7 +9819,9 @@
         }
       ],
       "meta": {
-        "tags": ["stepper"],
+        "tags": [
+          "stepper"
+        ],
         "colSpan": 3
       }
     },
@@ -7733,7 +9835,9 @@
         }
       ],
       "meta": {
-        "tags": ["stepper"],
+        "tags": [
+          "stepper"
+        ],
         "colSpan": 3
       }
     },
@@ -7747,7 +9851,9 @@
         }
       ],
       "meta": {
-        "tags": ["stepper"],
+        "tags": [
+          "stepper"
+        ],
         "colSpan": 3
       }
     },
@@ -7761,7 +9867,10 @@
         }
       ],
       "meta": {
-        "tags": ["stepper", "vertical stepper"],
+        "tags": [
+          "stepper",
+          "vertical stepper"
+        ],
         "colSpan": 2
       }
     },
@@ -7775,7 +9884,10 @@
         }
       ],
       "meta": {
-        "tags": ["stepper", "vertical stepper"],
+        "tags": [
+          "stepper",
+          "vertical stepper"
+        ],
         "colSpan": 2
       }
     },
@@ -7789,7 +9901,10 @@
         }
       ],
       "meta": {
-        "tags": ["stepper", "vertical stepper"],
+        "tags": [
+          "stepper",
+          "vertical stepper"
+        ],
         "colSpan": 2
       }
     },
@@ -7803,7 +9918,10 @@
         }
       ],
       "meta": {
-        "tags": ["stepper", "vertical stepper"],
+        "tags": [
+          "stepper",
+          "vertical stepper"
+        ],
         "colSpan": 2
       }
     },
@@ -7817,7 +9935,10 @@
         }
       ],
       "meta": {
-        "tags": ["timeline", "vertical timeline"],
+        "tags": [
+          "timeline",
+          "vertical timeline"
+        ],
         "colSpan": 2
       }
     },
@@ -7831,7 +9952,10 @@
         }
       ],
       "meta": {
-        "tags": ["timeline", "vertical timeline"],
+        "tags": [
+          "timeline",
+          "vertical timeline"
+        ],
         "colSpan": 2
       }
     },
@@ -7845,7 +9969,10 @@
         }
       ],
       "meta": {
-        "tags": ["timeline", "vertical timeline"],
+        "tags": [
+          "timeline",
+          "vertical timeline"
+        ],
         "colSpan": 2
       }
     },
@@ -7859,7 +9986,10 @@
         }
       ],
       "meta": {
-        "tags": ["timeline", "vertical timeline"],
+        "tags": [
+          "timeline",
+          "vertical timeline"
+        ],
         "colSpan": 2
       }
     },
@@ -7873,7 +10003,10 @@
         }
       ],
       "meta": {
-        "tags": ["timeline", "vertical timeline"],
+        "tags": [
+          "timeline",
+          "vertical timeline"
+        ],
         "colSpan": 2
       }
     },
@@ -7887,7 +10020,10 @@
         }
       ],
       "meta": {
-        "tags": ["timeline", "vertical timeline"],
+        "tags": [
+          "timeline",
+          "vertical timeline"
+        ],
         "colSpan": 2
       }
     },
@@ -7901,7 +10037,10 @@
         }
       ],
       "meta": {
-        "tags": ["timeline", "vertical timeline"],
+        "tags": [
+          "timeline",
+          "vertical timeline"
+        ],
         "colSpan": 2
       }
     },
@@ -7915,7 +10054,10 @@
         }
       ],
       "meta": {
-        "tags": ["timeline", "vertical timeline"],
+        "tags": [
+          "timeline",
+          "vertical timeline"
+        ],
         "colSpan": 2
       }
     },
@@ -7929,7 +10071,10 @@
         }
       ],
       "meta": {
-        "tags": ["timeline", "vertical timeline"],
+        "tags": [
+          "timeline",
+          "vertical timeline"
+        ],
         "colSpan": 2
       }
     },
@@ -7943,7 +10088,10 @@
         }
       ],
       "meta": {
-        "tags": ["timeline", "vertical timeline"],
+        "tags": [
+          "timeline",
+          "vertical timeline"
+        ],
         "colSpan": 2
       }
     },
@@ -7957,7 +10105,9 @@
         }
       ],
       "meta": {
-        "tags": ["timeline"],
+        "tags": [
+          "timeline"
+        ],
         "colSpan": 3
       }
     },
@@ -7971,7 +10121,9 @@
         }
       ],
       "meta": {
-        "tags": ["timeline"],
+        "tags": [
+          "timeline"
+        ],
         "colSpan": 3
       }
     },
@@ -7985,7 +10137,9 @@
         }
       ],
       "meta": {
-        "tags": ["calendar"],
+        "tags": [
+          "calendar"
+        ],
         "colSpan": 3
       }
     },
@@ -7999,7 +10153,13 @@
         }
       ],
       "meta": {
-        "tags": ["upload", "file", "drag and drop", "avatar"]
+        "tags": [
+          "upload",
+          "file",
+          "image",
+          "drag and drop",
+          "avatar"
+        ]
       }
     },
     {
@@ -8012,7 +10172,12 @@
         }
       ],
       "meta": {
-        "tags": ["upload", "file", "drag and drop"],
+        "tags": [
+          "upload",
+          "file",
+          "image",
+          "drag and drop"
+        ],
         "colSpan": 2
       }
     },
@@ -8026,7 +10191,12 @@
         }
       ],
       "meta": {
-        "tags": ["upload", "file", "drag and drop"],
+        "tags": [
+          "upload",
+          "file",
+          "image",
+          "drag and drop"
+        ],
         "colSpan": 2
       }
     },
@@ -8040,7 +10210,12 @@
         }
       ],
       "meta": {
-        "tags": ["upload", "file", "drag and drop"],
+        "tags": [
+          "upload",
+          "file",
+          "image",
+          "drag and drop"
+        ],
         "colSpan": 2
       }
     },
@@ -8054,7 +10229,12 @@
         }
       ],
       "meta": {
-        "tags": ["upload", "file", "drag and drop"],
+        "tags": [
+          "upload",
+          "file",
+          "image",
+          "drag and drop"
+        ],
         "colSpan": 2
       }
     },
@@ -8068,7 +10248,12 @@
         }
       ],
       "meta": {
-        "tags": ["upload", "file", "drag and drop"],
+        "tags": [
+          "upload",
+          "file",
+          "image",
+          "drag and drop"
+        ],
         "colSpan": 2
       }
     },
@@ -8082,7 +10267,12 @@
         }
       ],
       "meta": {
-        "tags": ["upload", "file", "drag and drop"],
+        "tags": [
+          "upload",
+          "file",
+          "image",
+          "drag and drop"
+        ],
         "colSpan": 2
       }
     },
@@ -8096,7 +10286,12 @@
         }
       ],
       "meta": {
-        "tags": ["upload", "file", "drag and drop"],
+        "tags": [
+          "upload",
+          "file",
+          "image",
+          "drag and drop"
+        ],
         "colSpan": 2
       }
     },
@@ -8110,7 +10305,12 @@
         }
       ],
       "meta": {
-        "tags": ["upload", "file", "drag and drop"],
+        "tags": [
+          "upload",
+          "file",
+          "image",
+          "drag and drop"
+        ],
         "colSpan": 2
       }
     },
@@ -8124,7 +10324,12 @@
         }
       ],
       "meta": {
-        "tags": ["upload", "file", "drag and drop"],
+        "tags": [
+          "upload",
+          "file",
+          "image",
+          "drag and drop"
+        ],
         "colSpan": 2
       }
     },
@@ -8138,7 +10343,216 @@
         }
       ],
       "meta": {
-        "tags": ["upload", "file", "drag and drop"],
+        "tags": [
+          "upload",
+          "file",
+          "image",
+          "drag and drop"
+        ],
+        "colSpan": 2
+      }
+    },
+    {
+      "name": "comp-554",
+      "type": "registry:component",
+      "files": [
+        {
+          "path": "registry/default/components/comp-554.tsx",
+          "type": "registry:component"
+        }
+      ],
+      "meta": {
+        "tags": [
+          "upload",
+          "file",
+          "image",
+          "drag and drop",
+          "crop",
+          "dialog",
+          "slider",
+          "zoom"
+        ],
+        "colSpan": 3
+      }
+    },
+    {
+      "name": "comp-555",
+      "type": "registry:component",
+      "files": [
+        {
+          "path": "registry/default/components/comp-555.tsx",
+          "type": "registry:component"
+        }
+      ],
+      "meta": {
+        "tags": [
+          "image",
+          "crop",
+          "zoom"
+        ],
+        "colSpan": 2
+      }
+    },
+    {
+      "name": "comp-556",
+      "type": "registry:component",
+      "files": [
+        {
+          "path": "registry/default/components/comp-556.tsx",
+          "type": "registry:component"
+        }
+      ],
+      "meta": {
+        "tags": [
+          "image",
+          "crop",
+          "zoom"
+        ],
+        "colSpan": 2
+      }
+    },
+    {
+      "name": "comp-557",
+      "type": "registry:component",
+      "files": [
+        {
+          "path": "registry/default/components/comp-557.tsx",
+          "type": "registry:component"
+        }
+      ],
+      "meta": {
+        "tags": [
+          "image",
+          "crop",
+          "zoom"
+        ],
+        "colSpan": 2
+      }
+    },
+    {
+      "name": "comp-558",
+      "type": "registry:component",
+      "files": [
+        {
+          "path": "registry/default/components/comp-558.tsx",
+          "type": "registry:component"
+        }
+      ],
+      "meta": {
+        "tags": [
+          "image",
+          "crop",
+          "zoom"
+        ],
+        "colSpan": 2
+      }
+    },
+    {
+      "name": "comp-559",
+      "type": "registry:component",
+      "files": [
+        {
+          "path": "registry/default/components/comp-559.tsx",
+          "type": "registry:component"
+        }
+      ],
+      "meta": {
+        "tags": [
+          "image",
+          "crop",
+          "zoom"
+        ],
+        "colSpan": 2
+      }
+    },
+    {
+      "name": "comp-560",
+      "type": "registry:component",
+      "files": [
+        {
+          "path": "registry/default/components/comp-560.tsx",
+          "type": "registry:component"
+        }
+      ],
+      "meta": {
+        "tags": [
+          "image",
+          "crop",
+          "zoom"
+        ],
+        "colSpan": 2
+      }
+    },
+    {
+      "name": "comp-561",
+      "type": "registry:component",
+      "files": [
+        {
+          "path": "registry/default/components/comp-561.tsx",
+          "type": "registry:component"
+        }
+      ],
+      "meta": {
+        "tags": [
+          "image",
+          "crop",
+          "zoom",
+          "slider"
+        ],
+        "colSpan": 2
+      }
+    },
+    {
+      "name": "comp-562",
+      "type": "registry:component",
+      "files": [
+        {
+          "path": "registry/default/components/comp-562.tsx",
+          "type": "registry:component"
+        }
+      ],
+      "meta": {
+        "tags": [
+          "image",
+          "crop",
+          "zoom"
+        ],
+        "colSpan": 2
+      }
+    },
+    {
+      "name": "comp-563",
+      "type": "registry:component",
+      "files": [
+        {
+          "path": "registry/default/components/comp-563.tsx",
+          "type": "registry:component"
+        }
+      ],
+      "meta": {
+        "tags": [
+          "image",
+          "crop",
+          "zoom"
+        ],
+        "colSpan": 2
+      }
+    },
+    {
+      "name": "comp-564",
+      "type": "registry:component",
+      "files": [
+        {
+          "path": "registry/default/components/comp-564.tsx",
+          "type": "registry:component"
+        }
+      ],
+      "meta": {
+        "tags": [
+          "image",
+          "crop",
+          "zoom"
+        ],
         "colSpan": 2
       }
     }

--- a/registry.json
+++ b/registry.json
@@ -1242,7 +1242,7 @@
       "type": "registry:component",
       "files": [
         {
-          "path": "registry/default/components/comp-63.tsx",
+          "path": "registry/default/components/comp-62.tsx",
           "type": "registry:component"
         }
       ],
@@ -3491,7 +3491,16 @@
         }
       ],
       "meta": {
-        "tags": ["label", "select", "command", "combobox", "popover", "search", "autocomplete", "radix"]
+        "tags": [
+          "label",
+          "select",
+          "command",
+          "combobox",
+          "popover",
+          "search",
+          "autocomplete",
+          "radix"
+        ]
       }
     },
     {
@@ -3504,7 +3513,16 @@
         }
       ],
       "meta": {
-        "tags": ["label", "select", "command", "combobox", "popover", "search", "autocomplete", "radix"]
+        "tags": [
+          "label",
+          "select",
+          "command",
+          "combobox",
+          "popover",
+          "search",
+          "autocomplete",
+          "radix"
+        ]
       }
     },
     {
@@ -3517,7 +3535,18 @@
         }
       ],
       "meta": {
-        "tags": ["label", "select", "command", "combobox", "popover", "search", "autocomplete", "timezone", "time", "radix"]
+        "tags": [
+          "label",
+          "select",
+          "command",
+          "combobox",
+          "popover",
+          "search",
+          "autocomplete",
+          "timezone",
+          "time",
+          "radix"
+        ]
       }
     },
     {
@@ -3530,7 +3559,17 @@
         }
       ],
       "meta": {
-        "tags": ["label", "select", "command", "combobox", "popover", "search", "autocomplete", "flag", "radix"]
+        "tags": [
+          "label",
+          "select",
+          "command",
+          "combobox",
+          "popover",
+          "search",
+          "autocomplete",
+          "flag",
+          "radix"
+        ]
       }
     },
     {
@@ -3543,7 +3582,16 @@
         }
       ],
       "meta": {
-        "tags": ["label", "select", "command", "combobox", "popover", "search", "autocomplete", "radix"]
+        "tags": [
+          "label",
+          "select",
+          "command",
+          "combobox",
+          "popover",
+          "search",
+          "autocomplete",
+          "radix"
+        ]
       }
     },
     {
@@ -3556,7 +3604,16 @@
         }
       ],
       "meta": {
-        "tags": ["label", "select", "multiselect", "tag", "input", "search", "autocomplete", "radix"]
+        "tags": [
+          "label",
+          "select",
+          "multiselect",
+          "tag",
+          "input",
+          "search",
+          "autocomplete",
+          "radix"
+        ]
       }
     },
     {
@@ -3569,7 +3626,16 @@
         }
       ],
       "meta": {
-        "tags": ["label", "select", "multiselect", "tag", "input", "search", "autocomplete", "radix"]
+        "tags": [
+          "label",
+          "select",
+          "multiselect",
+          "tag",
+          "input",
+          "search",
+          "autocomplete",
+          "radix"
+        ]
       }
     },
     {
@@ -4931,7 +4997,17 @@
         }
       ],
       "meta": {
-        "tags": ["dialog", "modal", "command", "combobox", "popover", "search", "radix", "autocomplete", "radix"],
+        "tags": [
+          "dialog",
+          "modal",
+          "command",
+          "combobox",
+          "popover",
+          "search",
+          "radix",
+          "autocomplete",
+          "radix"
+        ],
         "style": 1
       }
     },
@@ -6989,7 +7065,17 @@
         }
       ],
       "meta": {
-        "tags": ["table", "tanstack", "checkbox", "search", "select", "range", "input", "filter", "sort"],
+        "tags": [
+          "table",
+          "tanstack",
+          "checkbox",
+          "search",
+          "select",
+          "range",
+          "input",
+          "filter",
+          "sort"
+        ],
         "colSpan": 3
       }
     },
@@ -7087,7 +7173,18 @@
         }
       ],
       "meta": {
-        "tags": ["table", "tanstack", "checkbox", "sort", "flag", "badge", "chip", "pagination", "filter", "select"],
+        "tags": [
+          "table",
+          "tanstack",
+          "checkbox",
+          "sort",
+          "flag",
+          "badge",
+          "chip",
+          "pagination",
+          "filter",
+          "select"
+        ],
         "colSpan": 3
       }
     },

--- a/registry.json
+++ b/registry.json
@@ -463,10 +463,7 @@
         }
       ],
       "meta": {
-        "tags": [
-          "input",
-          "label"
-        ]
+        "tags": ["input", "label"]
       }
     },
     {
@@ -479,11 +476,7 @@
         }
       ],
       "meta": {
-        "tags": [
-          "input",
-          "label",
-          "required"
-        ]
+        "tags": ["input", "label", "required"]
       }
     },
     {
@@ -496,11 +489,7 @@
         }
       ],
       "meta": {
-        "tags": [
-          "input",
-          "label",
-          "helper"
-        ]
+        "tags": ["input", "label", "helper"]
       }
     },
     {
@@ -513,11 +502,7 @@
         }
       ],
       "meta": {
-        "tags": [
-          "input",
-          "label",
-          "hint"
-        ]
+        "tags": ["input", "label", "hint"]
       }
     },
     {
@@ -530,10 +515,7 @@
         }
       ],
       "meta": {
-        "tags": [
-          "input",
-          "label"
-        ]
+        "tags": ["input", "label"]
       }
     },
     {
@@ -546,11 +528,7 @@
         }
       ],
       "meta": {
-        "tags": [
-          "input",
-          "label",
-          "error"
-        ]
+        "tags": ["input", "label", "error"]
       }
     },
     {
@@ -563,10 +541,7 @@
         }
       ],
       "meta": {
-        "tags": [
-          "input",
-          "label"
-        ]
+        "tags": ["input", "label"]
       }
     },
     {
@@ -579,11 +554,7 @@
         }
       ],
       "meta": {
-        "tags": [
-          "input",
-          "label",
-          "disabled"
-        ]
+        "tags": ["input", "label", "disabled"]
       }
     },
     {
@@ -596,10 +567,7 @@
         }
       ],
       "meta": {
-        "tags": [
-          "input",
-          "label"
-        ]
+        "tags": ["input", "label"]
       }
     },
     {
@@ -612,10 +580,7 @@
         }
       ],
       "meta": {
-        "tags": [
-          "input",
-          "label"
-        ]
+        "tags": ["input", "label"]
       }
     },
     {
@@ -628,10 +593,7 @@
         }
       ],
       "meta": {
-        "tags": [
-          "input",
-          "label"
-        ]
+        "tags": ["input", "label"]
       }
     },
     {
@@ -644,10 +606,7 @@
         }
       ],
       "meta": {
-        "tags": [
-          "input",
-          "label"
-        ]
+        "tags": ["input", "label"]
       }
     },
     {
@@ -660,10 +619,7 @@
         }
       ],
       "meta": {
-        "tags": [
-          "input",
-          "label"
-        ]
+        "tags": ["input", "label"]
       }
     },
     {
@@ -676,10 +632,7 @@
         }
       ],
       "meta": {
-        "tags": [
-          "input",
-          "label"
-        ]
+        "tags": ["input", "label"]
       }
     },
     {
@@ -692,10 +645,7 @@
         }
       ],
       "meta": {
-        "tags": [
-          "input",
-          "label"
-        ]
+        "tags": ["input", "label"]
       }
     },
     {
@@ -708,10 +658,7 @@
         }
       ],
       "meta": {
-        "tags": [
-          "input",
-          "label"
-        ]
+        "tags": ["input", "label"]
       }
     },
     {
@@ -724,12 +671,7 @@
         }
       ],
       "meta": {
-        "tags": [
-          "input",
-          "label",
-          "select",
-          "native select"
-        ]
+        "tags": ["input", "label", "select", "native select"]
       }
     },
     {
@@ -742,12 +684,7 @@
         }
       ],
       "meta": {
-        "tags": [
-          "input",
-          "label",
-          "select",
-          "native select"
-        ]
+        "tags": ["input", "label", "select", "native select"]
       }
     },
     {
@@ -760,11 +697,7 @@
         }
       ],
       "meta": {
-        "tags": [
-          "input",
-          "label",
-          "button"
-        ]
+        "tags": ["input", "label", "button"]
       }
     },
     {
@@ -777,11 +710,7 @@
         }
       ],
       "meta": {
-        "tags": [
-          "input",
-          "label",
-          "button"
-        ]
+        "tags": ["input", "label", "button"]
       }
     },
     {
@@ -794,11 +723,7 @@
         }
       ],
       "meta": {
-        "tags": [
-          "input",
-          "label",
-          "button"
-        ]
+        "tags": ["input", "label", "button"]
       }
     },
     {
@@ -811,11 +736,7 @@
         }
       ],
       "meta": {
-        "tags": [
-          "input",
-          "label",
-          "button"
-        ]
+        "tags": ["input", "label", "button"]
       }
     },
     {
@@ -828,12 +749,7 @@
         }
       ],
       "meta": {
-        "tags": [
-          "input",
-          "label",
-          "button",
-          "password"
-        ]
+        "tags": ["input", "label", "button", "password"]
       }
     },
     {
@@ -846,11 +762,7 @@
         }
       ],
       "meta": {
-        "tags": [
-          "input",
-          "label",
-          "button"
-        ]
+        "tags": ["input", "label", "button"]
       }
     },
     {
@@ -863,12 +775,7 @@
         }
       ],
       "meta": {
-        "tags": [
-          "input",
-          "label",
-          "search",
-          "kbd"
-        ]
+        "tags": ["input", "label", "search", "kbd"]
       }
     },
     {
@@ -881,12 +788,7 @@
         }
       ],
       "meta": {
-        "tags": [
-          "input",
-          "label",
-          "button",
-          "search"
-        ]
+        "tags": ["input", "label", "button", "search"]
       }
     },
     {
@@ -899,12 +801,7 @@
         }
       ],
       "meta": {
-        "tags": [
-          "input",
-          "label",
-          "button",
-          "search"
-        ]
+        "tags": ["input", "label", "button", "search"]
       }
     },
     {
@@ -917,13 +814,7 @@
         }
       ],
       "meta": {
-        "tags": [
-          "input",
-          "label",
-          "button",
-          "number",
-          "react aria"
-        ]
+        "tags": ["input", "label", "button", "number", "react aria"]
       }
     },
     {
@@ -936,13 +827,7 @@
         }
       ],
       "meta": {
-        "tags": [
-          "input",
-          "label",
-          "button",
-          "number",
-          "react aria"
-        ]
+        "tags": ["input", "label", "button", "number", "react aria"]
       }
     },
     {
@@ -955,11 +840,7 @@
         }
       ],
       "meta": {
-        "tags": [
-          "input",
-          "label",
-          "file"
-        ]
+        "tags": ["input", "label", "file"]
       }
     },
     {
@@ -972,10 +853,7 @@
         }
       ],
       "meta": {
-        "tags": [
-          "input",
-          "label"
-        ]
+        "tags": ["input", "label"]
       }
     },
     {
@@ -988,10 +866,7 @@
         }
       ],
       "meta": {
-        "tags": [
-          "input",
-          "label"
-        ]
+        "tags": ["input", "label"]
       }
     },
     {
@@ -1004,10 +879,7 @@
         }
       ],
       "meta": {
-        "tags": [
-          "input",
-          "label"
-        ]
+        "tags": ["input", "label"]
       }
     },
     {
@@ -1020,10 +892,7 @@
         }
       ],
       "meta": {
-        "tags": [
-          "input",
-          "label"
-        ]
+        "tags": ["input", "label"]
       }
     },
     {
@@ -1036,10 +905,7 @@
         }
       ],
       "meta": {
-        "tags": [
-          "input",
-          "label"
-        ]
+        "tags": ["input", "label"]
       }
     },
     {
@@ -1052,12 +918,7 @@
         }
       ],
       "meta": {
-        "tags": [
-          "input",
-          "label",
-          "date",
-          "react aria"
-        ]
+        "tags": ["input", "label", "date", "react aria"]
       }
     },
     {
@@ -1070,12 +931,7 @@
         }
       ],
       "meta": {
-        "tags": [
-          "input",
-          "label",
-          "date",
-          "react aria"
-        ]
+        "tags": ["input", "label", "date", "react aria"]
       }
     },
     {
@@ -1088,12 +944,7 @@
         }
       ],
       "meta": {
-        "tags": [
-          "input",
-          "label",
-          "date",
-          "react aria"
-        ]
+        "tags": ["input", "label", "date", "react aria"]
       }
     },
     {
@@ -1106,12 +957,7 @@
         }
       ],
       "meta": {
-        "tags": [
-          "input",
-          "label",
-          "date",
-          "react aria"
-        ]
+        "tags": ["input", "label", "date", "react aria"]
       }
     },
     {
@@ -1124,12 +970,7 @@
         }
       ],
       "meta": {
-        "tags": [
-          "input",
-          "label",
-          "date",
-          "react aria"
-        ]
+        "tags": ["input", "label", "date", "react aria"]
       }
     },
     {
@@ -1142,14 +983,7 @@
         }
       ],
       "meta": {
-        "tags": [
-          "input",
-          "label",
-          "date",
-          "calendar",
-          "picker",
-          "react aria"
-        ]
+        "tags": ["input", "label", "date", "calendar", "picker", "react aria"]
       }
     },
     {
@@ -1162,15 +996,7 @@
         }
       ],
       "meta": {
-        "tags": [
-          "input",
-          "label",
-          "date",
-          "calendar",
-          "range calendar",
-          "picker",
-          "react aria"
-        ]
+        "tags": ["input", "label", "date", "calendar", "range calendar", "picker", "react aria"]
       }
     },
     {
@@ -1183,15 +1009,7 @@
         }
       ],
       "meta": {
-        "tags": [
-          "input",
-          "label",
-          "date",
-          "calendar",
-          "range calendar",
-          "picker",
-          "react aria"
-        ]
+        "tags": ["input", "label", "date", "calendar", "range calendar", "picker", "react aria"]
       }
     },
     {
@@ -1204,11 +1022,7 @@
         }
       ],
       "meta": {
-        "tags": [
-          "input",
-          "label",
-          "otp"
-        ]
+        "tags": ["input", "label", "otp"]
       }
     },
     {
@@ -1221,11 +1035,7 @@
         }
       ],
       "meta": {
-        "tags": [
-          "input",
-          "label",
-          "otp"
-        ]
+        "tags": ["input", "label", "otp"]
       }
     },
     {
@@ -1238,11 +1048,7 @@
         }
       ],
       "meta": {
-        "tags": [
-          "input",
-          "label",
-          "phone"
-        ]
+        "tags": ["input", "label", "phone"]
       }
     },
     {
@@ -1255,14 +1061,7 @@
         }
       ],
       "meta": {
-        "tags": [
-          "input",
-          "label",
-          "checkout",
-          "payment",
-          "credit card",
-          "form"
-        ]
+        "tags": ["input", "label", "checkout", "payment", "credit card", "form"]
       }
     },
     {
@@ -1275,14 +1074,7 @@
         }
       ],
       "meta": {
-        "tags": [
-          "input",
-          "label",
-          "checkout",
-          "payment",
-          "credit card",
-          "form"
-        ]
+        "tags": ["input", "label", "checkout", "payment", "credit card", "form"]
       }
     },
     {
@@ -1295,14 +1087,7 @@
         }
       ],
       "meta": {
-        "tags": [
-          "input",
-          "label",
-          "checkout",
-          "payment",
-          "credit card",
-          "form"
-        ]
+        "tags": ["input", "label", "checkout", "payment", "credit card", "form"]
       }
     },
     {
@@ -1315,14 +1100,7 @@
         }
       ],
       "meta": {
-        "tags": [
-          "input",
-          "label",
-          "checkout",
-          "payment",
-          "credit card",
-          "form"
-        ]
+        "tags": ["input", "label", "checkout", "payment", "credit card", "form"]
       }
     },
     {
@@ -1335,11 +1113,7 @@
         }
       ],
       "meta": {
-        "tags": [
-          "input",
-          "label",
-          "password"
-        ]
+        "tags": ["input", "label", "password"]
       }
     },
     {
@@ -1352,11 +1126,7 @@
         }
       ],
       "meta": {
-        "tags": [
-          "input",
-          "label",
-          "read-only"
-        ]
+        "tags": ["input", "label", "read-only"]
       }
     },
     {
@@ -1369,11 +1139,7 @@
         }
       ],
       "meta": {
-        "tags": [
-          "input",
-          "label",
-          "copy"
-        ]
+        "tags": ["input", "label", "copy"]
       }
     },
     {
@@ -1386,11 +1152,7 @@
         }
       ],
       "meta": {
-        "tags": [
-          "input",
-          "label",
-          "mask"
-        ]
+        "tags": ["input", "label", "mask"]
       }
     },
     {
@@ -1403,12 +1165,7 @@
         }
       ],
       "meta": {
-        "tags": [
-          "input",
-          "label",
-          "mask",
-          "time"
-        ]
+        "tags": ["input", "label", "mask", "time"]
       }
     },
     {
@@ -1421,12 +1178,7 @@
         }
       ],
       "meta": {
-        "tags": [
-          "input",
-          "label",
-          "tag",
-          "emblor"
-        ]
+        "tags": ["input", "label", "tag", "emblor"]
       }
     },
     {
@@ -1439,12 +1191,7 @@
         }
       ],
       "meta": {
-        "tags": [
-          "input",
-          "label",
-          "tag",
-          "emblor"
-        ]
+        "tags": ["input", "label", "tag", "emblor"]
       }
     },
     {
@@ -1457,11 +1204,7 @@
         }
       ],
       "meta": {
-        "tags": [
-          "input",
-          "label",
-          "otp"
-        ]
+        "tags": ["input", "label", "otp"]
       }
     },
     {
@@ -1474,10 +1217,7 @@
         }
       ],
       "meta": {
-        "tags": [
-          "label",
-          "textarea"
-        ]
+        "tags": ["label", "textarea"]
       }
     },
     {
@@ -1490,11 +1230,7 @@
         }
       ],
       "meta": {
-        "tags": [
-          "label",
-          "textarea",
-          "required"
-        ]
+        "tags": ["label", "textarea", "required"]
       }
     },
     {
@@ -1507,11 +1243,7 @@
         }
       ],
       "meta": {
-        "tags": [
-          "label",
-          "textarea",
-          "helper"
-        ]
+        "tags": ["label", "textarea", "helper"]
       }
     },
     {
@@ -1524,11 +1256,7 @@
         }
       ],
       "meta": {
-        "tags": [
-          "label",
-          "textarea",
-          "hint"
-        ]
+        "tags": ["label", "textarea", "hint"]
       }
     },
     {
@@ -1541,10 +1269,7 @@
         }
       ],
       "meta": {
-        "tags": [
-          "label",
-          "textarea"
-        ]
+        "tags": ["label", "textarea"]
       }
     },
     {
@@ -1557,11 +1282,7 @@
         }
       ],
       "meta": {
-        "tags": [
-          "label",
-          "textarea",
-          "error"
-        ]
+        "tags": ["label", "textarea", "error"]
       }
     },
     {
@@ -1574,10 +1295,7 @@
         }
       ],
       "meta": {
-        "tags": [
-          "label",
-          "textarea"
-        ]
+        "tags": ["label", "textarea"]
       }
     },
     {
@@ -1590,10 +1308,7 @@
         }
       ],
       "meta": {
-        "tags": [
-          "label",
-          "textarea"
-        ]
+        "tags": ["label", "textarea"]
       }
     },
     {
@@ -1606,11 +1321,7 @@
         }
       ],
       "meta": {
-        "tags": [
-          "label",
-          "textarea",
-          "disabled"
-        ]
+        "tags": ["label", "textarea", "disabled"]
       }
     },
     {
@@ -1623,11 +1334,7 @@
         }
       ],
       "meta": {
-        "tags": [
-          "label",
-          "textarea",
-          "button"
-        ]
+        "tags": ["label", "textarea", "button"]
       }
     },
     {
@@ -1640,11 +1347,7 @@
         }
       ],
       "meta": {
-        "tags": [
-          "label",
-          "textarea",
-          "button"
-        ]
+        "tags": ["label", "textarea", "button"]
       }
     },
     {
@@ -1657,11 +1360,7 @@
         }
       ],
       "meta": {
-        "tags": [
-          "label",
-          "textarea",
-          "button"
-        ]
+        "tags": ["label", "textarea", "button"]
       }
     },
     {
@@ -1674,10 +1373,7 @@
         }
       ],
       "meta": {
-        "tags": [
-          "label",
-          "textarea"
-        ]
+        "tags": ["label", "textarea"]
       }
     },
     {
@@ -1690,10 +1386,7 @@
         }
       ],
       "meta": {
-        "tags": [
-          "label",
-          "textarea"
-        ]
+        "tags": ["label", "textarea"]
       }
     },
     {
@@ -1706,10 +1399,7 @@
         }
       ],
       "meta": {
-        "tags": [
-          "label",
-          "textarea"
-        ]
+        "tags": ["label", "textarea"]
       }
     },
     {
@@ -1722,10 +1412,7 @@
         }
       ],
       "meta": {
-        "tags": [
-          "label",
-          "textarea"
-        ]
+        "tags": ["label", "textarea"]
       }
     },
     {
@@ -1738,10 +1425,7 @@
         }
       ],
       "meta": {
-        "tags": [
-          "label",
-          "textarea"
-        ]
+        "tags": ["label", "textarea"]
       }
     },
     {
@@ -1754,11 +1438,7 @@
         }
       ],
       "meta": {
-        "tags": [
-          "label",
-          "textarea",
-          "read-only"
-        ]
+        "tags": ["label", "textarea", "read-only"]
       }
     },
     {
@@ -1771,10 +1451,7 @@
         }
       ],
       "meta": {
-        "tags": [
-          "label",
-          "textarea"
-        ]
+        "tags": ["label", "textarea"]
       }
     },
     {
@@ -1787,9 +1464,7 @@
         }
       ],
       "meta": {
-        "tags": [
-          "button"
-        ],
+        "tags": ["button"],
         "style": 2
       }
     },
@@ -1803,10 +1478,7 @@
         }
       ],
       "meta": {
-        "tags": [
-          "button",
-          "disabled"
-        ],
+        "tags": ["button", "disabled"],
         "style": 2
       }
     },
@@ -1820,9 +1492,7 @@
         }
       ],
       "meta": {
-        "tags": [
-          "button"
-        ],
+        "tags": ["button"],
         "style": 2
       }
     },
@@ -1836,9 +1506,7 @@
         }
       ],
       "meta": {
-        "tags": [
-          "button"
-        ],
+        "tags": ["button"],
         "style": 2
       }
     },
@@ -1852,10 +1520,7 @@
         }
       ],
       "meta": {
-        "tags": [
-          "button",
-          "delete"
-        ],
+        "tags": ["button", "delete"],
         "style": 2
       }
     },
@@ -1869,9 +1534,7 @@
         }
       ],
       "meta": {
-        "tags": [
-          "button"
-        ],
+        "tags": ["button"],
         "style": 2
       }
     },
@@ -1885,9 +1548,7 @@
         }
       ],
       "meta": {
-        "tags": [
-          "button"
-        ],
+        "tags": ["button"],
         "style": 2
       }
     },
@@ -1901,10 +1562,7 @@
         }
       ],
       "meta": {
-        "tags": [
-          "button",
-          "back"
-        ],
+        "tags": ["button", "back"],
         "style": 2
       }
     },
@@ -1918,10 +1576,7 @@
         }
       ],
       "meta": {
-        "tags": [
-          "button",
-          "next"
-        ],
+        "tags": ["button", "next"],
         "style": 2
       }
     },
@@ -1935,9 +1590,7 @@
         }
       ],
       "meta": {
-        "tags": [
-          "button"
-        ],
+        "tags": ["button"],
         "style": 2
       }
     },
@@ -1951,10 +1604,7 @@
         }
       ],
       "meta": {
-        "tags": [
-          "button",
-          "dropdown"
-        ],
+        "tags": ["button", "dropdown"],
         "style": 2
       }
     },
@@ -1968,9 +1618,7 @@
         }
       ],
       "meta": {
-        "tags": [
-          "button"
-        ],
+        "tags": ["button"],
         "style": 2
       }
     },
@@ -1984,10 +1632,7 @@
         }
       ],
       "meta": {
-        "tags": [
-          "button",
-          "loading"
-        ],
+        "tags": ["button", "loading"],
         "style": 2
       }
     },
@@ -2001,10 +1646,7 @@
         }
       ],
       "meta": {
-        "tags": [
-          "button",
-          "loading"
-        ],
+        "tags": ["button", "loading"],
         "style": 2
       }
     },
@@ -2018,10 +1660,7 @@
         }
       ],
       "meta": {
-        "tags": [
-          "button",
-          "counter"
-        ],
+        "tags": ["button", "counter"],
         "style": 2
       }
     },
@@ -2035,10 +1674,7 @@
         }
       ],
       "meta": {
-        "tags": [
-          "button",
-          "kbd"
-        ],
+        "tags": ["button", "kbd"],
         "style": 2
       }
     },
@@ -2052,12 +1688,7 @@
         }
       ],
       "meta": {
-        "tags": [
-          "button",
-          "user",
-          "avatar",
-          "profile"
-        ],
+        "tags": ["button", "user", "avatar", "profile"],
         "style": 2
       }
     },
@@ -2071,13 +1702,7 @@
         }
       ],
       "meta": {
-        "tags": [
-          "button",
-          "user",
-          "avatar",
-          "profile",
-          "dropdown"
-        ],
+        "tags": ["button", "user", "avatar", "profile", "dropdown"],
         "style": 2
       }
     },
@@ -2091,9 +1716,7 @@
         }
       ],
       "meta": {
-        "tags": [
-          "button"
-        ],
+        "tags": ["button"],
         "style": 2
       }
     },
@@ -2107,9 +1730,7 @@
         }
       ],
       "meta": {
-        "tags": [
-          "button"
-        ],
+        "tags": ["button"],
         "style": 2
       }
     },
@@ -2123,10 +1744,7 @@
         }
       ],
       "meta": {
-        "tags": [
-          "button",
-          "menu"
-        ],
+        "tags": ["button", "menu"],
         "style": 2
       }
     },
@@ -2140,10 +1758,7 @@
         }
       ],
       "meta": {
-        "tags": [
-          "button",
-          "tooltip"
-        ],
+        "tags": ["button", "tooltip"],
         "style": 2
       }
     },
@@ -2157,11 +1772,7 @@
         }
       ],
       "meta": {
-        "tags": [
-          "button",
-          "menu",
-          "hamburger"
-        ],
+        "tags": ["button", "menu", "hamburger"],
         "style": 2
       }
     },
@@ -2175,10 +1786,7 @@
         }
       ],
       "meta": {
-        "tags": [
-          "button",
-          "toggle"
-        ],
+        "tags": ["button", "toggle"],
         "style": 2
       }
     },
@@ -2192,11 +1800,7 @@
         }
       ],
       "meta": {
-        "tags": [
-          "button",
-          "vote",
-          "counter"
-        ],
+        "tags": ["button", "vote", "counter"],
         "style": 2
       }
     },
@@ -2210,11 +1814,7 @@
         }
       ],
       "meta": {
-        "tags": [
-          "button",
-          "vote",
-          "counter"
-        ],
+        "tags": ["button", "vote", "counter"],
         "style": 2
       }
     },
@@ -2228,11 +1828,7 @@
         }
       ],
       "meta": {
-        "tags": [
-          "button",
-          "volume",
-          "controls"
-        ],
+        "tags": ["button", "volume", "controls"],
         "style": 2
       }
     },
@@ -2246,10 +1842,7 @@
         }
       ],
       "meta": {
-        "tags": [
-          "button",
-          "copy"
-        ],
+        "tags": ["button", "copy"],
         "style": 2
       }
     },
@@ -2263,10 +1856,7 @@
         }
       ],
       "meta": {
-        "tags": [
-          "button",
-          "toggle group"
-        ],
+        "tags": ["button", "toggle group"],
         "style": 2
       }
     },
@@ -2280,10 +1870,7 @@
         }
       ],
       "meta": {
-        "tags": [
-          "button",
-          "toggle group"
-        ],
+        "tags": ["button", "toggle group"],
         "style": 2
       }
     },
@@ -2297,11 +1884,7 @@
         }
       ],
       "meta": {
-        "tags": [
-          "button",
-          "toggle group",
-          "dropdown"
-        ],
+        "tags": ["button", "toggle group", "dropdown"],
         "style": 2
       }
     },
@@ -2315,10 +1898,7 @@
         }
       ],
       "meta": {
-        "tags": [
-          "button",
-          "toggle group"
-        ],
+        "tags": ["button", "toggle group"],
         "style": 2
       }
     },
@@ -2332,10 +1912,7 @@
         }
       ],
       "meta": {
-        "tags": [
-          "button",
-          "toggle group"
-        ],
+        "tags": ["button", "toggle group"],
         "style": 2
       }
     },
@@ -2349,9 +1926,7 @@
         }
       ],
       "meta": {
-        "tags": [
-          "button"
-        ],
+        "tags": ["button"],
         "style": 2
       }
     },
@@ -2365,9 +1940,7 @@
         }
       ],
       "meta": {
-        "tags": [
-          "button"
-        ],
+        "tags": ["button"],
         "style": 2
       }
     },
@@ -2381,10 +1954,7 @@
         }
       ],
       "meta": {
-        "tags": [
-          "button",
-          "dropdown"
-        ],
+        "tags": ["button", "dropdown"],
         "style": 2
       }
     },
@@ -2398,11 +1968,7 @@
         }
       ],
       "meta": {
-        "tags": [
-          "button",
-          "dropdown",
-          "counter"
-        ],
+        "tags": ["button", "dropdown", "counter"],
         "style": 2
       }
     },
@@ -2416,10 +1982,7 @@
         }
       ],
       "meta": {
-        "tags": [
-          "button",
-          "previous"
-        ],
+        "tags": ["button", "previous"],
         "style": 2
       }
     },
@@ -2433,10 +1996,7 @@
         }
       ],
       "meta": {
-        "tags": [
-          "button",
-          "next"
-        ],
+        "tags": ["button", "next"],
         "style": 2
       }
     },
@@ -2450,11 +2010,7 @@
         }
       ],
       "meta": {
-        "tags": [
-          "button",
-          "like",
-          "counter"
-        ],
+        "tags": ["button", "like", "counter"],
         "style": 2
       }
     },
@@ -2468,11 +2024,7 @@
         }
       ],
       "meta": {
-        "tags": [
-          "button",
-          "like",
-          "counter"
-        ],
+        "tags": ["button", "like", "counter"],
         "style": 2
       }
     },
@@ -2486,12 +2038,7 @@
         }
       ],
       "meta": {
-        "tags": [
-          "button",
-          "social",
-          "login",
-          "authentication"
-        ],
+        "tags": ["button", "social", "login", "authentication"],
         "style": 2
       }
     },
@@ -2505,12 +2052,7 @@
         }
       ],
       "meta": {
-        "tags": [
-          "button",
-          "social",
-          "login",
-          "authentication"
-        ],
+        "tags": ["button", "social", "login", "authentication"],
         "style": 2
       }
     },
@@ -2524,12 +2066,7 @@
         }
       ],
       "meta": {
-        "tags": [
-          "button",
-          "social",
-          "login",
-          "authentication"
-        ],
+        "tags": ["button", "social", "login", "authentication"],
         "style": 2
       }
     },
@@ -2543,12 +2080,7 @@
         }
       ],
       "meta": {
-        "tags": [
-          "button",
-          "social",
-          "login",
-          "authentication"
-        ],
+        "tags": ["button", "social", "login", "authentication"],
         "style": 2
       }
     },
@@ -2562,10 +2094,7 @@
         }
       ],
       "meta": {
-        "tags": [
-          "button",
-          "collapsible"
-        ],
+        "tags": ["button", "collapsible"],
         "style": 2
       }
     },
@@ -2579,10 +2108,7 @@
         }
       ],
       "meta": {
-        "tags": [
-          "button",
-          "back"
-        ],
+        "tags": ["button", "back"],
         "style": 2
       }
     },
@@ -2596,14 +2122,7 @@
         }
       ],
       "meta": {
-        "tags": [
-          "button",
-          "upload",
-          "user",
-          "avatar",
-          "profile",
-          "image"
-        ],
+        "tags": ["button", "upload", "user", "avatar", "profile", "image"],
         "style": 2
       }
     },
@@ -2617,14 +2136,7 @@
         }
       ],
       "meta": {
-        "tags": [
-          "button",
-          "upload",
-          "user",
-          "avatar",
-          "profile",
-          "image"
-        ],
+        "tags": ["button", "upload", "user", "avatar", "profile", "image"],
         "style": 2
       }
     },
@@ -2638,9 +2150,7 @@
         }
       ],
       "meta": {
-        "tags": [
-          "button"
-        ],
+        "tags": ["button"],
         "style": 2
       }
     },
@@ -2654,9 +2164,7 @@
         }
       ],
       "meta": {
-        "tags": [
-          "button"
-        ],
+        "tags": ["button"],
         "style": 2
       }
     },
@@ -2670,11 +2178,7 @@
         }
       ],
       "meta": {
-        "tags": [
-          "button",
-          "dropdown",
-          "notification"
-        ],
+        "tags": ["button", "dropdown", "notification"],
         "style": 2
       }
     },
@@ -2688,11 +2192,7 @@
         }
       ],
       "meta": {
-        "tags": [
-          "button",
-          "toggle",
-          "darkmode"
-        ],
+        "tags": ["button", "toggle", "darkmode"],
         "style": 2
       }
     },
@@ -2706,10 +2206,7 @@
         }
       ],
       "meta": {
-        "tags": [
-          "button",
-          "dropdown"
-        ],
+        "tags": ["button", "dropdown"],
         "style": 2
       }
     },
@@ -2723,11 +2220,7 @@
         }
       ],
       "meta": {
-        "tags": [
-          "checkbox",
-          "label",
-          "radix"
-        ]
+        "tags": ["checkbox", "label", "radix"]
       }
     },
     {
@@ -2740,11 +2233,7 @@
         }
       ],
       "meta": {
-        "tags": [
-          "checkbox",
-          "label",
-          "radix"
-        ]
+        "tags": ["checkbox", "label", "radix"]
       }
     },
     {
@@ -2757,11 +2246,7 @@
         }
       ],
       "meta": {
-        "tags": [
-          "checkbox",
-          "label",
-          "radix"
-        ]
+        "tags": ["checkbox", "label", "radix"]
       }
     },
     {
@@ -2774,12 +2259,7 @@
         }
       ],
       "meta": {
-        "tags": [
-          "checkbox",
-          "label",
-          "disabled",
-          "radix"
-        ]
+        "tags": ["checkbox", "label", "disabled", "radix"]
       }
     },
     {
@@ -2792,11 +2272,7 @@
         }
       ],
       "meta": {
-        "tags": [
-          "checkbox",
-          "label",
-          "radix"
-        ]
+        "tags": ["checkbox", "label", "radix"]
       }
     },
     {
@@ -2809,11 +2285,7 @@
         }
       ],
       "meta": {
-        "tags": [
-          "checkbox",
-          "label",
-          "radix"
-        ]
+        "tags": ["checkbox", "label", "radix"]
       }
     },
     {
@@ -2826,13 +2298,7 @@
         }
       ],
       "meta": {
-        "tags": [
-          "checkbox",
-          "label",
-          "login",
-          "authentication",
-          "radix"
-        ]
+        "tags": ["checkbox", "label", "login", "authentication", "radix"]
       }
     },
     {
@@ -2845,11 +2311,7 @@
         }
       ],
       "meta": {
-        "tags": [
-          "checkbox",
-          "label",
-          "radix"
-        ]
+        "tags": ["checkbox", "label", "radix"]
       }
     },
     {
@@ -2862,11 +2324,7 @@
         }
       ],
       "meta": {
-        "tags": [
-          "checkbox",
-          "label",
-          "radix"
-        ]
+        "tags": ["checkbox", "label", "radix"]
       }
     },
     {
@@ -2879,11 +2337,7 @@
         }
       ],
       "meta": {
-        "tags": [
-          "checkbox",
-          "label",
-          "radix"
-        ]
+        "tags": ["checkbox", "label", "radix"]
       }
     },
     {
@@ -2896,12 +2350,7 @@
         }
       ],
       "meta": {
-        "tags": [
-          "checkbox",
-          "label",
-          "collapsible",
-          "radix"
-        ]
+        "tags": ["checkbox", "label", "collapsible", "radix"]
       }
     },
     {
@@ -2914,11 +2363,7 @@
         }
       ],
       "meta": {
-        "tags": [
-          "checkbox",
-          "label",
-          "radix"
-        ]
+        "tags": ["checkbox", "label", "radix"]
       }
     },
     {
@@ -2931,12 +2376,7 @@
         }
       ],
       "meta": {
-        "tags": [
-          "checkbox",
-          "label",
-          "card",
-          "radix"
-        ]
+        "tags": ["checkbox", "label", "card", "radix"]
       }
     },
     {
@@ -2949,12 +2389,7 @@
         }
       ],
       "meta": {
-        "tags": [
-          "checkbox",
-          "label",
-          "card",
-          "radix"
-        ]
+        "tags": ["checkbox", "label", "card", "radix"]
       }
     },
     {
@@ -2967,12 +2402,7 @@
         }
       ],
       "meta": {
-        "tags": [
-          "checkbox",
-          "label",
-          "card",
-          "radix"
-        ]
+        "tags": ["checkbox", "label", "card", "radix"]
       }
     },
     {
@@ -2985,12 +2415,7 @@
         }
       ],
       "meta": {
-        "tags": [
-          "checkbox",
-          "label",
-          "card",
-          "radix"
-        ]
+        "tags": ["checkbox", "label", "card", "radix"]
       }
     },
     {
@@ -3003,12 +2428,7 @@
         }
       ],
       "meta": {
-        "tags": [
-          "checkbox",
-          "label",
-          "tree",
-          "radix"
-        ]
+        "tags": ["checkbox", "label", "tree", "radix"]
       }
     },
     {
@@ -3021,13 +2441,7 @@
         }
       ],
       "meta": {
-        "tags": [
-          "checkbox",
-          "label",
-          "week",
-          "calendar",
-          "radix"
-        ]
+        "tags": ["checkbox", "label", "week", "calendar", "radix"]
       }
     },
     {
@@ -3040,13 +2454,7 @@
         }
       ],
       "meta": {
-        "tags": [
-          "checkbox",
-          "label",
-          "toggle",
-          "darkmode",
-          "radix"
-        ]
+        "tags": ["checkbox", "label", "toggle", "darkmode", "radix"]
       }
     },
     {
@@ -3059,11 +2467,7 @@
         }
       ],
       "meta": {
-        "tags": [
-          "checkbox",
-          "label",
-          "radix"
-        ]
+        "tags": ["checkbox", "label", "radix"]
       }
     },
     {
@@ -3076,11 +2480,7 @@
         }
       ],
       "meta": {
-        "tags": [
-          "radio",
-          "label",
-          "radix"
-        ]
+        "tags": ["radio", "label", "radix"]
       }
     },
     {
@@ -3093,11 +2493,7 @@
         }
       ],
       "meta": {
-        "tags": [
-          "radio",
-          "label",
-          "radix"
-        ]
+        "tags": ["radio", "label", "radix"]
       }
     },
     {
@@ -3110,11 +2506,7 @@
         }
       ],
       "meta": {
-        "tags": [
-          "radio",
-          "label",
-          "radix"
-        ]
+        "tags": ["radio", "label", "radix"]
       }
     },
     {
@@ -3127,11 +2519,7 @@
         }
       ],
       "meta": {
-        "tags": [
-          "radio",
-          "label",
-          "radix"
-        ]
+        "tags": ["radio", "label", "radix"]
       }
     },
     {
@@ -3144,12 +2532,7 @@
         }
       ],
       "meta": {
-        "tags": [
-          "radio",
-          "label",
-          "collapsible",
-          "radix"
-        ]
+        "tags": ["radio", "label", "collapsible", "radix"]
       }
     },
     {
@@ -3162,12 +2545,7 @@
         }
       ],
       "meta": {
-        "tags": [
-          "radio",
-          "label",
-          "rating",
-          "radix"
-        ]
+        "tags": ["radio", "label", "rating", "radix"]
       }
     },
     {
@@ -3180,13 +2558,7 @@
         }
       ],
       "meta": {
-        "tags": [
-          "radio",
-          "label",
-          "color",
-          "picker",
-          "radix"
-        ]
+        "tags": ["radio", "label", "color", "picker", "radix"]
       }
     },
     {
@@ -3199,12 +2571,7 @@
         }
       ],
       "meta": {
-        "tags": [
-          "radio",
-          "label",
-          "card",
-          "radix"
-        ]
+        "tags": ["radio", "label", "card", "radix"]
       }
     },
     {
@@ -3217,12 +2584,7 @@
         }
       ],
       "meta": {
-        "tags": [
-          "radio",
-          "label",
-          "card",
-          "radix"
-        ]
+        "tags": ["radio", "label", "card", "radix"]
       }
     },
     {
@@ -3235,12 +2597,7 @@
         }
       ],
       "meta": {
-        "tags": [
-          "radio",
-          "label",
-          "card",
-          "radix"
-        ]
+        "tags": ["radio", "label", "card", "radix"]
       }
     },
     {
@@ -3253,12 +2610,7 @@
         }
       ],
       "meta": {
-        "tags": [
-          "radio",
-          "label",
-          "card",
-          "radix"
-        ]
+        "tags": ["radio", "label", "card", "radix"]
       }
     },
     {
@@ -3271,14 +2623,7 @@
         }
       ],
       "meta": {
-        "tags": [
-          "radio",
-          "label",
-          "card",
-          "checkout",
-          "payment",
-          "radix"
-        ]
+        "tags": ["radio", "label", "card", "checkout", "payment", "radix"]
       }
     },
     {
@@ -3291,13 +2636,7 @@
         }
       ],
       "meta": {
-        "tags": [
-          "radio",
-          "label",
-          "card",
-          "pricing",
-          "radix"
-        ]
+        "tags": ["radio", "label", "card", "pricing", "radix"]
       }
     },
     {
@@ -3310,12 +2649,7 @@
         }
       ],
       "meta": {
-        "tags": [
-          "radio",
-          "label",
-          "card",
-          "radix"
-        ]
+        "tags": ["radio", "label", "card", "radix"]
       }
     },
     {
@@ -3328,12 +2662,7 @@
         }
       ],
       "meta": {
-        "tags": [
-          "radio",
-          "label",
-          "pricing",
-          "radix"
-        ]
+        "tags": ["radio", "label", "pricing", "radix"]
       }
     },
     {
@@ -3346,13 +2675,7 @@
         }
       ],
       "meta": {
-        "tags": [
-          "radio",
-          "label",
-          "rating",
-          "vote",
-          "radix"
-        ]
+        "tags": ["radio", "label", "rating", "vote", "radix"]
       }
     },
     {
@@ -3365,13 +2688,7 @@
         }
       ],
       "meta": {
-        "tags": [
-          "radio",
-          "label",
-          "rating",
-          "vote",
-          "radix"
-        ]
+        "tags": ["radio", "label", "rating", "vote", "radix"]
       }
     },
     {
@@ -3384,12 +2701,7 @@
         }
       ],
       "meta": {
-        "tags": [
-          "radio",
-          "label",
-          "darkmode",
-          "radix"
-        ]
+        "tags": ["radio", "label", "darkmode", "radix"]
       }
     },
     {
@@ -3402,13 +2714,7 @@
         }
       ],
       "meta": {
-        "tags": [
-          "radio",
-          "label",
-          "pricing",
-          "switch",
-          "radix"
-        ],
+        "tags": ["radio", "label", "pricing", "switch", "radix"],
         "style": 1
       }
     },
@@ -3422,13 +2728,7 @@
         }
       ],
       "meta": {
-        "tags": [
-          "radio",
-          "label",
-          "rating",
-          "vote",
-          "radix"
-        ],
+        "tags": ["radio", "label", "rating", "vote", "radix"],
         "style": 1
       }
     },
@@ -3442,10 +2742,7 @@
         }
       ],
       "meta": {
-        "tags": [
-          "switch",
-          "radix"
-        ],
+        "tags": ["switch", "radix"],
         "style": 1
       }
     },
@@ -3459,10 +2756,7 @@
         }
       ],
       "meta": {
-        "tags": [
-          "switch",
-          "radix"
-        ],
+        "tags": ["switch", "radix"],
         "style": 1
       }
     },
@@ -3476,10 +2770,7 @@
         }
       ],
       "meta": {
-        "tags": [
-          "switch",
-          "radix"
-        ],
+        "tags": ["switch", "radix"],
         "style": 1
       }
     },
@@ -3493,10 +2784,7 @@
         }
       ],
       "meta": {
-        "tags": [
-          "switch",
-          "radix"
-        ],
+        "tags": ["switch", "radix"],
         "style": 1
       }
     },
@@ -3510,10 +2798,7 @@
         }
       ],
       "meta": {
-        "tags": [
-          "switch",
-          "radix"
-        ],
+        "tags": ["switch", "radix"],
         "style": 1
       }
     },
@@ -3527,10 +2812,7 @@
         }
       ],
       "meta": {
-        "tags": [
-          "switch",
-          "radix"
-        ],
+        "tags": ["switch", "radix"],
         "style": 1
       }
     },
@@ -3544,10 +2826,7 @@
         }
       ],
       "meta": {
-        "tags": [
-          "switch",
-          "radix"
-        ],
+        "tags": ["switch", "radix"],
         "style": 1
       }
     },
@@ -3561,11 +2840,7 @@
         }
       ],
       "meta": {
-        "tags": [
-          "switch",
-          "label",
-          "radix"
-        ],
+        "tags": ["switch", "label", "radix"],
         "style": 1
       }
     },
@@ -3579,11 +2854,7 @@
         }
       ],
       "meta": {
-        "tags": [
-          "switch",
-          "label",
-          "radix"
-        ],
+        "tags": ["switch", "label", "radix"],
         "style": 1
       }
     },
@@ -3597,12 +2868,7 @@
         }
       ],
       "meta": {
-        "tags": [
-          "switch",
-          "label",
-          "darkmode",
-          "radix"
-        ],
+        "tags": ["switch", "label", "darkmode", "radix"],
         "style": 1
       }
     },
@@ -3616,12 +2882,7 @@
         }
       ],
       "meta": {
-        "tags": [
-          "switch",
-          "label",
-          "darkmode",
-          "radix"
-        ],
+        "tags": ["switch", "label", "darkmode", "radix"],
         "style": 1
       }
     },
@@ -3635,12 +2896,7 @@
         }
       ],
       "meta": {
-        "tags": [
-          "switch",
-          "label",
-          "darkmode",
-          "radix"
-        ],
+        "tags": ["switch", "label", "darkmode", "radix"],
         "style": 1
       }
     },
@@ -3654,12 +2910,7 @@
         }
       ],
       "meta": {
-        "tags": [
-          "switch",
-          "label",
-          "darkmode",
-          "radix"
-        ],
+        "tags": ["switch", "label", "darkmode", "radix"],
         "style": 1
       }
     },
@@ -3673,11 +2924,7 @@
         }
       ],
       "meta": {
-        "tags": [
-          "switch",
-          "label",
-          "radix"
-        ],
+        "tags": ["switch", "label", "radix"],
         "style": 1
       }
     },
@@ -3691,12 +2938,7 @@
         }
       ],
       "meta": {
-        "tags": [
-          "switch",
-          "label",
-          "card",
-          "radix"
-        ],
+        "tags": ["switch", "label", "card", "radix"],
         "style": 1
       }
     },
@@ -3710,12 +2952,7 @@
         }
       ],
       "meta": {
-        "tags": [
-          "switch",
-          "label",
-          "card",
-          "radix"
-        ],
+        "tags": ["switch", "label", "card", "radix"],
         "style": 1
       }
     },
@@ -3729,12 +2966,7 @@
         }
       ],
       "meta": {
-        "tags": [
-          "switch",
-          "label",
-          "card",
-          "radix"
-        ],
+        "tags": ["switch", "label", "card", "radix"],
         "style": 1
       }
     },
@@ -3748,11 +2980,7 @@
         }
       ],
       "meta": {
-        "tags": [
-          "label",
-          "select",
-          "native select"
-        ]
+        "tags": ["label", "select", "native select"]
       }
     },
     {
@@ -3765,11 +2993,7 @@
         }
       ],
       "meta": {
-        "tags": [
-          "label",
-          "select",
-          "native select"
-        ]
+        "tags": ["label", "select", "native select"]
       }
     },
     {
@@ -3782,12 +3006,7 @@
         }
       ],
       "meta": {
-        "tags": [
-          "label",
-          "select",
-          "native select",
-          "time"
-        ]
+        "tags": ["label", "select", "native select", "time"]
       }
     },
     {
@@ -3800,11 +3019,7 @@
         }
       ],
       "meta": {
-        "tags": [
-          "label",
-          "select",
-          "native select"
-        ]
+        "tags": ["label", "select", "native select"]
       }
     },
     {
@@ -3817,11 +3032,7 @@
         }
       ],
       "meta": {
-        "tags": [
-          "label",
-          "select",
-          "native select"
-        ]
+        "tags": ["label", "select", "native select"]
       }
     },
     {
@@ -3834,12 +3045,7 @@
         }
       ],
       "meta": {
-        "tags": [
-          "label",
-          "select",
-          "native select",
-          "error"
-        ]
+        "tags": ["label", "select", "native select", "error"]
       }
     },
     {
@@ -3852,11 +3058,7 @@
         }
       ],
       "meta": {
-        "tags": [
-          "label",
-          "select",
-          "native select"
-        ]
+        "tags": ["label", "select", "native select"]
       }
     },
     {
@@ -3869,12 +3071,7 @@
         }
       ],
       "meta": {
-        "tags": [
-          "label",
-          "select",
-          "native select",
-          "disabled"
-        ]
+        "tags": ["label", "select", "native select", "disabled"]
       }
     },
     {
@@ -3887,11 +3084,7 @@
         }
       ],
       "meta": {
-        "tags": [
-          "label",
-          "select",
-          "native select"
-        ]
+        "tags": ["label", "select", "native select"]
       }
     },
     {
@@ -3904,11 +3097,7 @@
         }
       ],
       "meta": {
-        "tags": [
-          "label",
-          "select",
-          "native select"
-        ]
+        "tags": ["label", "select", "native select"]
       }
     },
     {
@@ -3921,11 +3110,7 @@
         }
       ],
       "meta": {
-        "tags": [
-          "label",
-          "select",
-          "native select"
-        ]
+        "tags": ["label", "select", "native select"]
       }
     },
     {
@@ -3938,13 +3123,7 @@
         }
       ],
       "meta": {
-        "tags": [
-          "label",
-          "select",
-          "native select",
-          "timezone",
-          "time"
-        ]
+        "tags": ["label", "select", "native select", "timezone", "time"]
       }
     },
     {
@@ -3957,11 +3136,7 @@
         }
       ],
       "meta": {
-        "tags": [
-          "label",
-          "select",
-          "native select"
-        ]
+        "tags": ["label", "select", "native select"]
       }
     },
     {
@@ -3974,11 +3149,7 @@
         }
       ],
       "meta": {
-        "tags": [
-          "label",
-          "select",
-          "native select"
-        ]
+        "tags": ["label", "select", "native select"]
       }
     },
     {
@@ -3991,11 +3162,7 @@
         }
       ],
       "meta": {
-        "tags": [
-          "label",
-          "select",
-          "radix"
-        ]
+        "tags": ["label", "select", "radix"]
       }
     },
     {
@@ -4008,11 +3175,7 @@
         }
       ],
       "meta": {
-        "tags": [
-          "label",
-          "select",
-          "radix"
-        ]
+        "tags": ["label", "select", "radix"]
       }
     },
     {
@@ -4025,11 +3188,7 @@
         }
       ],
       "meta": {
-        "tags": [
-          "label",
-          "select",
-          "radix"
-        ]
+        "tags": ["label", "select", "radix"]
       }
     },
     {
@@ -4042,12 +3201,7 @@
         }
       ],
       "meta": {
-        "tags": [
-          "label",
-          "select",
-          "helper",
-          "radix"
-        ]
+        "tags": ["label", "select", "helper", "radix"]
       }
     },
     {
@@ -4060,11 +3214,7 @@
         }
       ],
       "meta": {
-        "tags": [
-          "label",
-          "select",
-          "radix"
-        ]
+        "tags": ["label", "select", "radix"]
       }
     },
     {
@@ -4077,11 +3227,7 @@
         }
       ],
       "meta": {
-        "tags": [
-          "label",
-          "select",
-          "radix"
-        ]
+        "tags": ["label", "select", "radix"]
       }
     },
     {
@@ -4094,11 +3240,7 @@
         }
       ],
       "meta": {
-        "tags": [
-          "label",
-          "select",
-          "radix"
-        ]
+        "tags": ["label", "select", "radix"]
       }
     },
     {
@@ -4111,12 +3253,7 @@
         }
       ],
       "meta": {
-        "tags": [
-          "label",
-          "select",
-          "disabled",
-          "radix"
-        ]
+        "tags": ["label", "select", "disabled", "radix"]
       }
     },
     {
@@ -4129,12 +3266,7 @@
         }
       ],
       "meta": {
-        "tags": [
-          "label",
-          "select",
-          "required",
-          "radix"
-        ]
+        "tags": ["label", "select", "required", "radix"]
       }
     },
     {
@@ -4147,11 +3279,7 @@
         }
       ],
       "meta": {
-        "tags": [
-          "label",
-          "select",
-          "radix"
-        ]
+        "tags": ["label", "select", "radix"]
       }
     },
     {
@@ -4164,11 +3292,7 @@
         }
       ],
       "meta": {
-        "tags": [
-          "label",
-          "select",
-          "radix"
-        ]
+        "tags": ["label", "select", "radix"]
       }
     },
     {
@@ -4181,11 +3305,7 @@
         }
       ],
       "meta": {
-        "tags": [
-          "label",
-          "select",
-          "radix"
-        ]
+        "tags": ["label", "select", "radix"]
       }
     },
     {
@@ -4198,12 +3318,7 @@
         }
       ],
       "meta": {
-        "tags": [
-          "label",
-          "select",
-          "disabled",
-          "radix"
-        ]
+        "tags": ["label", "select", "disabled", "radix"]
       }
     },
     {
@@ -4216,11 +3331,7 @@
         }
       ],
       "meta": {
-        "tags": [
-          "label",
-          "select",
-          "radix"
-        ]
+        "tags": ["label", "select", "radix"]
       }
     },
     {
@@ -4233,11 +3344,7 @@
         }
       ],
       "meta": {
-        "tags": [
-          "label",
-          "select",
-          "radix"
-        ]
+        "tags": ["label", "select", "radix"]
       }
     },
     {
@@ -4250,13 +3357,7 @@
         }
       ],
       "meta": {
-        "tags": [
-          "label",
-          "select",
-          "timezone",
-          "time",
-          "radix"
-        ]
+        "tags": ["label", "select", "timezone", "time", "radix"]
       }
     },
     {
@@ -4269,11 +3370,7 @@
         }
       ],
       "meta": {
-        "tags": [
-          "label",
-          "select",
-          "radix"
-        ]
+        "tags": ["label", "select", "radix"]
       }
     },
     {
@@ -4286,12 +3383,7 @@
         }
       ],
       "meta": {
-        "tags": [
-          "label",
-          "select",
-          "status",
-          "radix"
-        ]
+        "tags": ["label", "select", "status", "radix"]
       }
     },
     {
@@ -4304,11 +3396,7 @@
         }
       ],
       "meta": {
-        "tags": [
-          "label",
-          "select",
-          "radix"
-        ]
+        "tags": ["label", "select", "radix"]
       }
     },
     {
@@ -4321,11 +3409,7 @@
         }
       ],
       "meta": {
-        "tags": [
-          "label",
-          "select",
-          "radix"
-        ]
+        "tags": ["label", "select", "radix"]
       }
     },
     {
@@ -4338,11 +3422,7 @@
         }
       ],
       "meta": {
-        "tags": [
-          "label",
-          "select",
-          "radix"
-        ]
+        "tags": ["label", "select", "radix"]
       }
     },
     {
@@ -4355,11 +3435,7 @@
         }
       ],
       "meta": {
-        "tags": [
-          "label",
-          "select",
-          "radix"
-        ]
+        "tags": ["label", "select", "radix"]
       }
     },
     {
@@ -4372,12 +3448,7 @@
         }
       ],
       "meta": {
-        "tags": [
-          "label",
-          "select",
-          "flag",
-          "radix"
-        ]
+        "tags": ["label", "select", "flag", "radix"]
       }
     },
     {
@@ -4390,14 +3461,7 @@
         }
       ],
       "meta": {
-        "tags": [
-          "label",
-          "select",
-          "user",
-          "avatar",
-          "profile",
-          "radix"
-        ]
+        "tags": ["label", "select", "user", "avatar", "profile", "radix"]
       }
     },
     {
@@ -4410,14 +3474,7 @@
         }
       ],
       "meta": {
-        "tags": [
-          "label",
-          "select",
-          "user",
-          "avatar",
-          "profile",
-          "radix"
-        ]
+        "tags": ["label", "select", "user", "avatar", "profile", "radix"]
       }
     },
     {
@@ -4430,14 +3487,7 @@
         }
       ],
       "meta": {
-        "tags": [
-          "label",
-          "select",
-          "user",
-          "avatar",
-          "profile",
-          "radix"
-        ]
+        "tags": ["label", "select", "user", "avatar", "profile", "radix"]
       }
     },
     {
@@ -4607,12 +3657,7 @@
         }
       ],
       "meta": {
-        "tags": [
-          "label",
-          "select",
-          "multiselect",
-          "native select"
-        ]
+        "tags": ["label", "select", "multiselect", "native select"]
       }
     },
     {
@@ -4625,12 +3670,7 @@
         }
       ],
       "meta": {
-        "tags": [
-          "label",
-          "select",
-          "multiselect",
-          "react aria"
-        ]
+        "tags": ["label", "select", "multiselect", "react aria"]
       }
     },
     {
@@ -4643,12 +3683,7 @@
         }
       ],
       "meta": {
-        "tags": [
-          "label",
-          "select",
-          "multiselect",
-          "react aria"
-        ]
+        "tags": ["label", "select", "multiselect", "react aria"]
       }
     },
     {
@@ -4661,12 +3696,7 @@
         }
       ],
       "meta": {
-        "tags": [
-          "label",
-          "select",
-          "multiselect",
-          "react aria"
-        ]
+        "tags": ["label", "select", "multiselect", "react aria"]
       }
     },
     {
@@ -4679,11 +3709,7 @@
         }
       ],
       "meta": {
-        "tags": [
-          "slider",
-          "label",
-          "radix"
-        ]
+        "tags": ["slider", "label", "radix"]
       }
     },
     {
@@ -4696,12 +3722,7 @@
         }
       ],
       "meta": {
-        "tags": [
-          "slider",
-          "label",
-          "disabled",
-          "radix"
-        ]
+        "tags": ["slider", "label", "disabled", "radix"]
       }
     },
     {
@@ -4714,11 +3735,7 @@
         }
       ],
       "meta": {
-        "tags": [
-          "slider",
-          "label",
-          "radix"
-        ]
+        "tags": ["slider", "label", "radix"]
       }
     },
     {
@@ -4731,11 +3748,7 @@
         }
       ],
       "meta": {
-        "tags": [
-          "slider",
-          "label",
-          "radix"
-        ]
+        "tags": ["slider", "label", "radix"]
       }
     },
     {
@@ -4748,11 +3761,7 @@
         }
       ],
       "meta": {
-        "tags": [
-          "slider",
-          "label",
-          "radix"
-        ]
+        "tags": ["slider", "label", "radix"]
       }
     },
     {
@@ -4765,11 +3774,7 @@
         }
       ],
       "meta": {
-        "tags": [
-          "slider",
-          "label",
-          "radix"
-        ]
+        "tags": ["slider", "label", "radix"]
       }
     },
     {
@@ -4782,11 +3787,7 @@
         }
       ],
       "meta": {
-        "tags": [
-          "slider",
-          "label",
-          "radix"
-        ]
+        "tags": ["slider", "label", "radix"]
       }
     },
     {
@@ -4799,11 +3800,7 @@
         }
       ],
       "meta": {
-        "tags": [
-          "slider",
-          "label",
-          "radix"
-        ]
+        "tags": ["slider", "label", "radix"]
       }
     },
     {
@@ -4816,11 +3813,7 @@
         }
       ],
       "meta": {
-        "tags": [
-          "slider",
-          "label",
-          "radix"
-        ]
+        "tags": ["slider", "label", "radix"]
       }
     },
     {
@@ -4833,12 +3826,7 @@
         }
       ],
       "meta": {
-        "tags": [
-          "slider",
-          "label",
-          "tooltip",
-          "radix"
-        ]
+        "tags": ["slider", "label", "tooltip", "radix"]
       }
     },
     {
@@ -4851,13 +3839,7 @@
         }
       ],
       "meta": {
-        "tags": [
-          "slider",
-          "range slider",
-          "label",
-          "range",
-          "radix"
-        ]
+        "tags": ["slider", "range slider", "label", "range", "radix"]
       }
     },
     {
@@ -4870,13 +3852,7 @@
         }
       ],
       "meta": {
-        "tags": [
-          "slider",
-          "range slider",
-          "label",
-          "range",
-          "radix"
-        ]
+        "tags": ["slider", "range slider", "label", "range", "radix"]
       }
     },
     {
@@ -4889,13 +3865,7 @@
         }
       ],
       "meta": {
-        "tags": [
-          "slider",
-          "label",
-          "volume",
-          "controls",
-          "radix"
-        ]
+        "tags": ["slider", "label", "volume", "controls", "radix"]
       }
     },
     {
@@ -4908,13 +3878,7 @@
         }
       ],
       "meta": {
-        "tags": [
-          "slider",
-          "range slider",
-          "label",
-          "range",
-          "radix"
-        ]
+        "tags": ["slider", "range slider", "label", "range", "radix"]
       }
     },
     {
@@ -4927,15 +3891,7 @@
         }
       ],
       "meta": {
-        "tags": [
-          "slider",
-          "label",
-          "button",
-          "input",
-          "tooltip",
-          "reset",
-          "radix"
-        ]
+        "tags": ["slider", "label", "button", "input", "tooltip", "reset", "radix"]
       }
     },
     {
@@ -4948,12 +3904,7 @@
         }
       ],
       "meta": {
-        "tags": [
-          "slider",
-          "label",
-          "input",
-          "radix"
-        ]
+        "tags": ["slider", "label", "input", "radix"]
       }
     },
     {
@@ -4966,13 +3917,7 @@
         }
       ],
       "meta": {
-        "tags": [
-          "slider",
-          "label",
-          "vote",
-          "rating",
-          "radix"
-        ]
+        "tags": ["slider", "label", "vote", "rating", "radix"]
       }
     },
     {
@@ -4985,13 +3930,7 @@
         }
       ],
       "meta": {
-        "tags": [
-          "slider",
-          "label",
-          "vote",
-          "rating",
-          "radix"
-        ]
+        "tags": ["slider", "label", "vote", "rating", "radix"]
       }
     },
     {
@@ -5004,14 +3943,7 @@
         }
       ],
       "meta": {
-        "tags": [
-          "slider",
-          "range slider",
-          "label",
-          "input",
-          "range",
-          "radix"
-        ]
+        "tags": ["slider", "range slider", "label", "input", "range", "radix"]
       }
     },
     {
@@ -5024,13 +3956,7 @@
         }
       ],
       "meta": {
-        "tags": [
-          "slider",
-          "label",
-          "button",
-          "pricing",
-          "radix"
-        ]
+        "tags": ["slider", "label", "button", "pricing", "radix"]
       }
     },
     {
@@ -5043,13 +3969,7 @@
         }
       ],
       "meta": {
-        "tags": [
-          "slider",
-          "range slider",
-          "label",
-          "button",
-          "radix"
-        ]
+        "tags": ["slider", "range slider", "label", "button", "radix"]
       }
     },
     {
@@ -5062,12 +3982,7 @@
         }
       ],
       "meta": {
-        "tags": [
-          "slider",
-          "vertical slider",
-          "label",
-          "radix"
-        ]
+        "tags": ["slider", "vertical slider", "label", "radix"]
       }
     },
     {
@@ -5080,13 +3995,7 @@
         }
       ],
       "meta": {
-        "tags": [
-          "slider",
-          "vertical slider",
-          "label",
-          "input",
-          "radix"
-        ]
+        "tags": ["slider", "vertical slider", "label", "input", "radix"]
       }
     },
     {
@@ -5099,13 +4008,7 @@
         }
       ],
       "meta": {
-        "tags": [
-          "slider",
-          "vertical slider",
-          "range slider",
-          "label",
-          "radix"
-        ]
+        "tags": ["slider", "vertical slider", "range slider", "label", "radix"]
       }
     },
     {
@@ -5118,14 +4021,7 @@
         }
       ],
       "meta": {
-        "tags": [
-          "slider",
-          "label",
-          "input",
-          "button",
-          "reset",
-          "radix"
-        ]
+        "tags": ["slider", "label", "input", "button", "reset", "radix"]
       }
     },
     {
@@ -5138,13 +4034,7 @@
         }
       ],
       "meta": {
-        "tags": [
-          "slider",
-          "label",
-          "input",
-          "button",
-          "radix"
-        ]
+        "tags": ["slider", "label", "input", "button", "radix"]
       }
     },
     {
@@ -5157,12 +4047,7 @@
         }
       ],
       "meta": {
-        "tags": [
-          "slider",
-          "label",
-          "equalizer",
-          "radix"
-        ]
+        "tags": ["slider", "label", "equalizer", "radix"]
       }
     },
     {
@@ -5175,10 +4060,7 @@
         }
       ],
       "meta": {
-        "tags": [
-          "alert",
-          "warning"
-        ],
+        "tags": ["alert", "warning"],
         "colSpan": 2
       }
     },
@@ -5192,10 +4074,7 @@
         }
       ],
       "meta": {
-        "tags": [
-          "alert",
-          "warning"
-        ],
+        "tags": ["alert", "warning"],
         "colSpan": 2
       }
     },
@@ -5209,10 +4088,7 @@
         }
       ],
       "meta": {
-        "tags": [
-          "alert",
-          "error"
-        ],
+        "tags": ["alert", "error"],
         "colSpan": 2
       }
     },
@@ -5226,10 +4102,7 @@
         }
       ],
       "meta": {
-        "tags": [
-          "alert",
-          "error"
-        ],
+        "tags": ["alert", "error"],
         "colSpan": 2
       }
     },
@@ -5243,10 +4116,7 @@
         }
       ],
       "meta": {
-        "tags": [
-          "alert",
-          "success"
-        ],
+        "tags": ["alert", "success"],
         "colSpan": 2
       }
     },
@@ -5260,10 +4130,7 @@
         }
       ],
       "meta": {
-        "tags": [
-          "alert",
-          "success"
-        ],
+        "tags": ["alert", "success"],
         "colSpan": 2
       }
     },
@@ -5277,10 +4144,7 @@
         }
       ],
       "meta": {
-        "tags": [
-          "alert",
-          "info"
-        ],
+        "tags": ["alert", "info"],
         "colSpan": 2
       }
     },
@@ -5294,10 +4158,7 @@
         }
       ],
       "meta": {
-        "tags": [
-          "alert",
-          "info"
-        ],
+        "tags": ["alert", "info"],
         "colSpan": 2
       }
     },
@@ -5311,10 +4172,7 @@
         }
       ],
       "meta": {
-        "tags": [
-          "alert",
-          "warning"
-        ],
+        "tags": ["alert", "warning"],
         "colSpan": 2
       }
     },
@@ -5328,10 +4186,7 @@
         }
       ],
       "meta": {
-        "tags": [
-          "alert",
-          "warning"
-        ],
+        "tags": ["alert", "warning"],
         "colSpan": 2
       }
     },
@@ -5345,12 +4200,7 @@
         }
       ],
       "meta": {
-        "tags": [
-          "alert",
-          "error",
-          "signup",
-          "authentication"
-        ],
+        "tags": ["alert", "error", "signup", "authentication"],
         "colSpan": 2
       }
     },
@@ -5364,12 +4214,7 @@
         }
       ],
       "meta": {
-        "tags": [
-          "alert",
-          "error",
-          "signup",
-          "authentication"
-        ],
+        "tags": ["alert", "error", "signup", "authentication"],
         "colSpan": 2
       }
     },
@@ -5383,10 +4228,7 @@
         }
       ],
       "meta": {
-        "tags": [
-          "notification",
-          "warning"
-        ],
+        "tags": ["notification", "warning"],
         "colSpan": 2,
         "style": 1
       }
@@ -5401,10 +4243,7 @@
         }
       ],
       "meta": {
-        "tags": [
-          "notification",
-          "error"
-        ],
+        "tags": ["notification", "error"],
         "colSpan": 2,
         "style": 1
       }
@@ -5419,10 +4258,7 @@
         }
       ],
       "meta": {
-        "tags": [
-          "notification",
-          "success"
-        ],
+        "tags": ["notification", "success"],
         "colSpan": 2,
         "style": 1
       }
@@ -5437,10 +4273,7 @@
         }
       ],
       "meta": {
-        "tags": [
-          "notification",
-          "info"
-        ],
+        "tags": ["notification", "info"],
         "colSpan": 2,
         "style": 1
       }
@@ -5455,10 +4288,7 @@
         }
       ],
       "meta": {
-        "tags": [
-          "notification",
-          "warning"
-        ],
+        "tags": ["notification", "warning"],
         "colSpan": 2,
         "style": 1
       }
@@ -5473,10 +4303,7 @@
         }
       ],
       "meta": {
-        "tags": [
-          "notification",
-          "error"
-        ],
+        "tags": ["notification", "error"],
         "colSpan": 2,
         "style": 1
       }
@@ -5491,10 +4318,7 @@
         }
       ],
       "meta": {
-        "tags": [
-          "notification",
-          "success"
-        ],
+        "tags": ["notification", "success"],
         "colSpan": 2,
         "style": 1
       }
@@ -5509,10 +4333,7 @@
         }
       ],
       "meta": {
-        "tags": [
-          "notification",
-          "info"
-        ],
+        "tags": ["notification", "info"],
         "colSpan": 2,
         "style": 1
       }
@@ -5527,11 +4348,7 @@
         }
       ],
       "meta": {
-        "tags": [
-          "notification",
-          "button",
-          "success"
-        ],
+        "tags": ["notification", "button", "success"],
         "colSpan": 2,
         "style": 1
       }
@@ -5546,10 +4363,7 @@
         }
       ],
       "meta": {
-        "tags": [
-          "notification",
-          "success"
-        ],
+        "tags": ["notification", "success"],
         "colSpan": 2,
         "style": 1
       }
@@ -5564,11 +4378,7 @@
         }
       ],
       "meta": {
-        "tags": [
-          "notification",
-          "button",
-          "warning"
-        ],
+        "tags": ["notification", "button", "warning"],
         "colSpan": 2,
         "style": 1
       }
@@ -5583,11 +4393,7 @@
         }
       ],
       "meta": {
-        "tags": [
-          "notification",
-          "button",
-          "error"
-        ],
+        "tags": ["notification", "button", "error"],
         "colSpan": 2,
         "style": 1
       }
@@ -5602,11 +4408,7 @@
         }
       ],
       "meta": {
-        "tags": [
-          "notification",
-          "button",
-          "success"
-        ],
+        "tags": ["notification", "button", "success"],
         "colSpan": 2,
         "style": 1
       }
@@ -5621,11 +4423,7 @@
         }
       ],
       "meta": {
-        "tags": [
-          "notification",
-          "button",
-          "info"
-        ],
+        "tags": ["notification", "button", "info"],
         "colSpan": 2,
         "style": 1
       }
@@ -5640,13 +4438,7 @@
         }
       ],
       "meta": {
-        "tags": [
-          "notification",
-          "button",
-          "cookies",
-          "gdpr",
-          "privacy"
-        ],
+        "tags": ["notification", "button", "cookies", "gdpr", "privacy"],
         "colSpan": 2,
         "style": 1
       }
@@ -5661,11 +4453,7 @@
         }
       ],
       "meta": {
-        "tags": [
-          "notification",
-          "button",
-          "info"
-        ],
+        "tags": ["notification", "button", "info"],
         "colSpan": 2,
         "style": 1
       }
@@ -5680,10 +4468,7 @@
         }
       ],
       "meta": {
-        "tags": [
-          "notification",
-          "button"
-        ],
+        "tags": ["notification", "button"],
         "colSpan": 2,
         "style": 1
       }
@@ -5698,10 +4483,7 @@
         }
       ],
       "meta": {
-        "tags": [
-          "notification",
-          "button"
-        ],
+        "tags": ["notification", "button"],
         "colSpan": 2,
         "style": 1
       }
@@ -5716,11 +4498,7 @@
         }
       ],
       "meta": {
-        "tags": [
-          "notification",
-          "toast",
-          "radix"
-        ],
+        "tags": ["notification", "toast", "radix"],
         "colSpan": 2,
         "style": 1
       }
@@ -5735,12 +4513,7 @@
         }
       ],
       "meta": {
-        "tags": [
-          "notification",
-          "toast",
-          "success",
-          "radix"
-        ],
+        "tags": ["notification", "toast", "success", "radix"],
         "colSpan": 2,
         "style": 1
       }
@@ -5755,12 +4528,7 @@
         }
       ],
       "meta": {
-        "tags": [
-          "notification",
-          "toast",
-          "sonner",
-          "radix"
-        ],
+        "tags": ["notification", "toast", "sonner", "radix"],
         "colSpan": 2,
         "style": 1
       }
@@ -5775,13 +4543,7 @@
         }
       ],
       "meta": {
-        "tags": [
-          "notification",
-          "toast",
-          "sonner",
-          "success",
-          "radix"
-        ],
+        "tags": ["notification", "toast", "sonner", "success", "radix"],
         "colSpan": 2,
         "style": 1
       }
@@ -5796,12 +4558,7 @@
         }
       ],
       "meta": {
-        "tags": [
-          "banner",
-          "cookies",
-          "gdpr",
-          "privacy"
-        ],
+        "tags": ["banner", "cookies", "gdpr", "privacy"],
         "colSpan": 3
       }
     },
@@ -5815,9 +4572,7 @@
         }
       ],
       "meta": {
-        "tags": [
-          "banner"
-        ],
+        "tags": ["banner"],
         "colSpan": 3
       }
     },
@@ -5831,9 +4586,7 @@
         }
       ],
       "meta": {
-        "tags": [
-          "banner"
-        ],
+        "tags": ["banner"],
         "colSpan": 3
       }
     },
@@ -5847,9 +4600,7 @@
         }
       ],
       "meta": {
-        "tags": [
-          "banner"
-        ],
+        "tags": ["banner"],
         "colSpan": 3
       }
     },
@@ -5863,9 +4614,7 @@
         }
       ],
       "meta": {
-        "tags": [
-          "banner"
-        ],
+        "tags": ["banner"],
         "colSpan": 3
       }
     },
@@ -5879,9 +4628,7 @@
         }
       ],
       "meta": {
-        "tags": [
-          "banner"
-        ],
+        "tags": ["banner"],
         "colSpan": 3
       }
     },
@@ -5895,9 +4642,7 @@
         }
       ],
       "meta": {
-        "tags": [
-          "banner"
-        ],
+        "tags": ["banner"],
         "colSpan": 3
       }
     },
@@ -5911,9 +4656,7 @@
         }
       ],
       "meta": {
-        "tags": [
-          "banner"
-        ],
+        "tags": ["banner"],
         "colSpan": 3
       }
     },
@@ -5927,9 +4670,7 @@
         }
       ],
       "meta": {
-        "tags": [
-          "banner"
-        ],
+        "tags": ["banner"],
         "colSpan": 3
       }
     },
@@ -5943,11 +4684,7 @@
         }
       ],
       "meta": {
-        "tags": [
-          "banner",
-          "countdown",
-          "sale"
-        ],
+        "tags": ["banner", "countdown", "sale"],
         "colSpan": 3
       }
     },
@@ -5961,11 +4698,7 @@
         }
       ],
       "meta": {
-        "tags": [
-          "banner",
-          "newsletter",
-          "subscribe"
-        ],
+        "tags": ["banner", "newsletter", "subscribe"],
         "colSpan": 3
       }
     },
@@ -5979,9 +4712,7 @@
         }
       ],
       "meta": {
-        "tags": [
-          "banner"
-        ],
+        "tags": ["banner"],
         "colSpan": 3
       }
     },
@@ -5995,13 +4726,7 @@
         }
       ],
       "meta": {
-        "tags": [
-          "dialog",
-          "modal",
-          "alert",
-          "alert dialog",
-          "radix"
-        ],
+        "tags": ["dialog", "modal", "alert", "alert dialog", "radix"],
         "style": 1
       }
     },
@@ -6015,13 +4740,7 @@
         }
       ],
       "meta": {
-        "tags": [
-          "dialog",
-          "modal",
-          "alert",
-          "alert dialog",
-          "radix"
-        ],
+        "tags": ["dialog", "modal", "alert", "alert dialog", "radix"],
         "style": 1
       }
     },
@@ -6035,11 +4754,7 @@
         }
       ],
       "meta": {
-        "tags": [
-          "dialog",
-          "modal",
-          "radix"
-        ],
+        "tags": ["dialog", "modal", "radix"],
         "style": 1
       }
     },
@@ -6053,11 +4768,7 @@
         }
       ],
       "meta": {
-        "tags": [
-          "dialog",
-          "modal",
-          "radix"
-        ],
+        "tags": ["dialog", "modal", "radix"],
         "style": 1
       }
     },
@@ -6071,11 +4782,7 @@
         }
       ],
       "meta": {
-        "tags": [
-          "dialog",
-          "modal",
-          "radix"
-        ],
+        "tags": ["dialog", "modal", "radix"],
         "style": 1
       }
     },
@@ -6089,11 +4796,7 @@
         }
       ],
       "meta": {
-        "tags": [
-          "dialog",
-          "modal",
-          "radix"
-        ],
+        "tags": ["dialog", "modal", "radix"],
         "style": 1
       }
     },
@@ -6107,11 +4810,7 @@
         }
       ],
       "meta": {
-        "tags": [
-          "dialog",
-          "modal",
-          "radix"
-        ],
+        "tags": ["dialog", "modal", "radix"],
         "style": 1
       }
     },
@@ -6125,12 +4824,7 @@
         }
       ],
       "meta": {
-        "tags": [
-          "dialog",
-          "modal",
-          "delete",
-          "radix"
-        ],
+        "tags": ["dialog", "modal", "delete", "radix"],
         "style": 1
       }
     },
@@ -6144,14 +4838,7 @@
         }
       ],
       "meta": {
-        "tags": [
-          "dialog",
-          "modal",
-          "newsletter",
-          "subscribe",
-          "form",
-          "radix"
-        ],
+        "tags": ["dialog", "modal", "newsletter", "subscribe", "form", "radix"],
         "style": 1
       }
     },
@@ -6165,13 +4852,7 @@
         }
       ],
       "meta": {
-        "tags": [
-          "dialog",
-          "modal",
-          "feedback",
-          "form",
-          "radix"
-        ],
+        "tags": ["dialog", "modal", "feedback", "form", "radix"],
         "style": 1
       }
     },
@@ -6185,14 +4866,7 @@
         }
       ],
       "meta": {
-        "tags": [
-          "dialog",
-          "modal",
-          "rating",
-          "feedback",
-          "form",
-          "radix"
-        ],
+        "tags": ["dialog", "modal", "rating", "feedback", "form", "radix"],
         "style": 1
       }
     },
@@ -6206,12 +4880,7 @@
         }
       ],
       "meta": {
-        "tags": [
-          "dialog",
-          "modal",
-          "otp",
-          "radix"
-        ],
+        "tags": ["dialog", "modal", "otp", "radix"],
         "style": 1
       }
     },
@@ -6225,14 +4894,7 @@
         }
       ],
       "meta": {
-        "tags": [
-          "dialog",
-          "modal",
-          "signup",
-          "authentication",
-          "form",
-          "radix"
-        ],
+        "tags": ["dialog", "modal", "signup", "authentication", "form", "radix"],
         "style": 1
       }
     },
@@ -6246,14 +4908,7 @@
         }
       ],
       "meta": {
-        "tags": [
-          "dialog",
-          "modal",
-          "login",
-          "authentication",
-          "form",
-          "radix"
-        ],
+        "tags": ["dialog", "modal", "login", "authentication", "form", "radix"],
         "style": 1
       }
     },
@@ -6267,14 +4922,7 @@
         }
       ],
       "meta": {
-        "tags": [
-          "dialog",
-          "modal",
-          "form",
-          "user",
-          "team",
-          "radix"
-        ],
+        "tags": ["dialog", "modal", "form", "user", "team", "radix"],
         "style": 1
       }
     },
@@ -6288,15 +4936,7 @@
         }
       ],
       "meta": {
-        "tags": [
-          "dialog",
-          "modal",
-          "checkout",
-          "payment",
-          "credit card",
-          "form",
-          "radix"
-        ],
+        "tags": ["dialog", "modal", "checkout", "payment", "credit card", "form", "radix"],
         "style": 1
       }
     },
@@ -6310,15 +4950,7 @@
         }
       ],
       "meta": {
-        "tags": [
-          "dialog",
-          "modal",
-          "checkout",
-          "payment",
-          "credit card",
-          "form",
-          "radix"
-        ],
+        "tags": ["dialog", "modal", "checkout", "payment", "credit card", "form", "radix"],
         "style": 1
       }
     },
@@ -6332,12 +4964,7 @@
         }
       ],
       "meta": {
-        "tags": [
-          "dialog",
-          "modal",
-          "user",
-          "radix"
-        ],
+        "tags": ["dialog", "modal", "user", "radix"],
         "style": 1
       }
     },
@@ -6351,16 +4978,7 @@
         }
       ],
       "meta": {
-        "tags": [
-          "dialog",
-          "modal",
-          "user",
-          "profile",
-          "image",
-          "avatar",
-          "form",
-          "radix"
-        ],
+        "tags": ["dialog", "modal", "user", "profile", "image", "avatar", "form", "radix"],
         "style": 1
       }
     },
@@ -6374,12 +4992,7 @@
         }
       ],
       "meta": {
-        "tags": [
-          "dialog",
-          "modal",
-          "onboarding",
-          "radix"
-        ],
+        "tags": ["dialog", "modal", "onboarding", "radix"],
         "style": 1
       }
     },
@@ -6417,10 +5030,7 @@
         }
       ],
       "meta": {
-        "tags": [
-          "accordion",
-          "radix"
-        ],
+        "tags": ["accordion", "radix"],
         "colSpan": 2
       }
     },
@@ -6434,10 +5044,7 @@
         }
       ],
       "meta": {
-        "tags": [
-          "accordion",
-          "radix"
-        ],
+        "tags": ["accordion", "radix"],
         "colSpan": 2
       }
     },
@@ -6451,10 +5058,7 @@
         }
       ],
       "meta": {
-        "tags": [
-          "accordion",
-          "radix"
-        ],
+        "tags": ["accordion", "radix"],
         "colSpan": 2
       }
     },
@@ -6468,10 +5072,7 @@
         }
       ],
       "meta": {
-        "tags": [
-          "accordion",
-          "radix"
-        ],
+        "tags": ["accordion", "radix"],
         "colSpan": 2
       }
     },
@@ -6485,10 +5086,7 @@
         }
       ],
       "meta": {
-        "tags": [
-          "accordion",
-          "radix"
-        ],
+        "tags": ["accordion", "radix"],
         "colSpan": 2
       }
     },
@@ -6502,10 +5100,7 @@
         }
       ],
       "meta": {
-        "tags": [
-          "accordion",
-          "radix"
-        ],
+        "tags": ["accordion", "radix"],
         "colSpan": 2
       }
     },
@@ -6519,10 +5114,7 @@
         }
       ],
       "meta": {
-        "tags": [
-          "accordion",
-          "radix"
-        ],
+        "tags": ["accordion", "radix"],
         "colSpan": 2
       }
     },
@@ -6536,10 +5128,7 @@
         }
       ],
       "meta": {
-        "tags": [
-          "accordion",
-          "radix"
-        ],
+        "tags": ["accordion", "radix"],
         "colSpan": 2
       }
     },
@@ -6553,10 +5142,7 @@
         }
       ],
       "meta": {
-        "tags": [
-          "accordion",
-          "radix"
-        ],
+        "tags": ["accordion", "radix"],
         "colSpan": 2
       }
     },
@@ -6570,10 +5156,7 @@
         }
       ],
       "meta": {
-        "tags": [
-          "accordion",
-          "radix"
-        ],
+        "tags": ["accordion", "radix"],
         "colSpan": 2
       }
     },
@@ -6587,10 +5170,7 @@
         }
       ],
       "meta": {
-        "tags": [
-          "accordion",
-          "radix"
-        ],
+        "tags": ["accordion", "radix"],
         "colSpan": 2
       }
     },
@@ -6604,10 +5184,7 @@
         }
       ],
       "meta": {
-        "tags": [
-          "accordion",
-          "radix"
-        ],
+        "tags": ["accordion", "radix"],
         "colSpan": 2
       }
     },
@@ -6621,10 +5198,7 @@
         }
       ],
       "meta": {
-        "tags": [
-          "accordion",
-          "radix"
-        ],
+        "tags": ["accordion", "radix"],
         "colSpan": 2
       }
     },
@@ -6638,10 +5212,7 @@
         }
       ],
       "meta": {
-        "tags": [
-          "accordion",
-          "radix"
-        ],
+        "tags": ["accordion", "radix"],
         "colSpan": 2
       }
     },
@@ -6655,10 +5226,7 @@
         }
       ],
       "meta": {
-        "tags": [
-          "accordion",
-          "radix"
-        ],
+        "tags": ["accordion", "radix"],
         "colSpan": 2
       }
     },
@@ -6672,10 +5240,7 @@
         }
       ],
       "meta": {
-        "tags": [
-          "accordion",
-          "radix"
-        ],
+        "tags": ["accordion", "radix"],
         "colSpan": 2
       }
     },
@@ -6689,10 +5254,7 @@
         }
       ],
       "meta": {
-        "tags": [
-          "accordion",
-          "radix"
-        ],
+        "tags": ["accordion", "radix"],
         "colSpan": 2
       }
     },
@@ -6706,10 +5268,7 @@
         }
       ],
       "meta": {
-        "tags": [
-          "accordion",
-          "radix"
-        ],
+        "tags": ["accordion", "radix"],
         "colSpan": 2
       }
     },
@@ -6723,11 +5282,7 @@
         }
       ],
       "meta": {
-        "tags": [
-          "accordion",
-          "collapsible",
-          "radix"
-        ],
+        "tags": ["accordion", "collapsible", "radix"],
         "colSpan": 2
       }
     },
@@ -6741,11 +5296,7 @@
         }
       ],
       "meta": {
-        "tags": [
-          "accordion",
-          "collapsible",
-          "radix"
-        ],
+        "tags": ["accordion", "collapsible", "radix"],
         "colSpan": 2
       }
     },
@@ -6759,10 +5310,7 @@
         }
       ],
       "meta": {
-        "tags": [
-          "tooltip",
-          "radix"
-        ],
+        "tags": ["tooltip", "radix"],
         "style": 1
       }
     },
@@ -6776,10 +5324,7 @@
         }
       ],
       "meta": {
-        "tags": [
-          "tooltip",
-          "radix"
-        ],
+        "tags": ["tooltip", "radix"],
         "style": 1
       }
     },
@@ -6793,10 +5338,7 @@
         }
       ],
       "meta": {
-        "tags": [
-          "tooltip",
-          "radix"
-        ],
+        "tags": ["tooltip", "radix"],
         "style": 1
       }
     },
@@ -6810,10 +5352,7 @@
         }
       ],
       "meta": {
-        "tags": [
-          "tooltip",
-          "radix"
-        ],
+        "tags": ["tooltip", "radix"],
         "style": 1
       }
     },
@@ -6827,10 +5366,7 @@
         }
       ],
       "meta": {
-        "tags": [
-          "tooltip",
-          "radix"
-        ],
+        "tags": ["tooltip", "radix"],
         "style": 1
       }
     },
@@ -6844,11 +5380,7 @@
         }
       ],
       "meta": {
-        "tags": [
-          "tooltip",
-          "image",
-          "radix"
-        ],
+        "tags": ["tooltip", "image", "radix"],
         "style": 1
       }
     },
@@ -6862,12 +5394,7 @@
         }
       ],
       "meta": {
-        "tags": [
-          "tooltip",
-          "button",
-          "kbd",
-          "radix"
-        ],
+        "tags": ["tooltip", "button", "kbd", "radix"],
         "style": 1
       }
     },
@@ -6881,10 +5408,7 @@
         }
       ],
       "meta": {
-        "tags": [
-          "tooltip",
-          "radix"
-        ],
+        "tags": ["tooltip", "radix"],
         "style": 1
       }
     },
@@ -6898,11 +5422,7 @@
         }
       ],
       "meta": {
-        "tags": [
-          "tooltip",
-          "chart",
-          "radix"
-        ],
+        "tags": ["tooltip", "chart", "radix"],
         "style": 1
       }
     },
@@ -6916,14 +5436,7 @@
         }
       ],
       "meta": {
-        "tags": [
-          "tooltip",
-          "hover card",
-          "user",
-          "avatar",
-          "profile",
-          "radix"
-        ],
+        "tags": ["tooltip", "hover card", "user", "avatar", "profile", "radix"],
         "style": 1
       }
     },
@@ -6937,14 +5450,7 @@
         }
       ],
       "meta": {
-        "tags": [
-          "tooltip",
-          "hover card",
-          "user",
-          "avatar",
-          "profile",
-          "radix"
-        ],
+        "tags": ["tooltip", "hover card", "user", "avatar", "profile", "radix"],
         "style": 1
       }
     },
@@ -6958,12 +5464,7 @@
         }
       ],
       "meta": {
-        "tags": [
-          "tooltip",
-          "hover card",
-          "image",
-          "radix"
-        ],
+        "tags": ["tooltip", "hover card", "image", "radix"],
         "style": 1
       }
     },
@@ -6977,10 +5478,7 @@
         }
       ],
       "meta": {
-        "tags": [
-          "dropdown",
-          "radix"
-        ],
+        "tags": ["dropdown", "radix"],
         "style": 1
       }
     },
@@ -6994,10 +5492,7 @@
         }
       ],
       "meta": {
-        "tags": [
-          "dropdown",
-          "radix"
-        ],
+        "tags": ["dropdown", "radix"],
         "style": 1
       }
     },
@@ -7011,10 +5506,7 @@
         }
       ],
       "meta": {
-        "tags": [
-          "dropdown",
-          "radix"
-        ],
+        "tags": ["dropdown", "radix"],
         "style": 1
       }
     },
@@ -7028,10 +5520,7 @@
         }
       ],
       "meta": {
-        "tags": [
-          "dropdown",
-          "radix"
-        ],
+        "tags": ["dropdown", "radix"],
         "style": 1
       }
     },
@@ -7045,10 +5534,7 @@
         }
       ],
       "meta": {
-        "tags": [
-          "dropdown",
-          "radix"
-        ],
+        "tags": ["dropdown", "radix"],
         "style": 1
       }
     },
@@ -7062,11 +5548,7 @@
         }
       ],
       "meta": {
-        "tags": [
-          "dropdown",
-          "checkbox",
-          "radix"
-        ],
+        "tags": ["dropdown", "checkbox", "radix"],
         "style": 1
       }
     },
@@ -7080,11 +5562,7 @@
         }
       ],
       "meta": {
-        "tags": [
-          "dropdown",
-          "radio",
-          "radix"
-        ],
+        "tags": ["dropdown", "radio", "radix"],
         "style": 1
       }
     },
@@ -7098,12 +5576,7 @@
         }
       ],
       "meta": {
-        "tags": [
-          "dropdown",
-          "kbd",
-          "delete",
-          "radix"
-        ],
+        "tags": ["dropdown", "kbd", "delete", "radix"],
         "style": 1
       }
     },
@@ -7117,13 +5590,7 @@
         }
       ],
       "meta": {
-        "tags": [
-          "dropdown",
-          "checkbox",
-          "radio",
-          "delete",
-          "radix"
-        ],
+        "tags": ["dropdown", "checkbox", "radio", "delete", "radix"],
         "style": 1
       }
     },
@@ -7137,12 +5604,7 @@
         }
       ],
       "meta": {
-        "tags": [
-          "dropdown",
-          "user",
-          "profile",
-          "radix"
-        ],
+        "tags": ["dropdown", "user", "profile", "radix"],
         "style": 1
       }
     },
@@ -7156,13 +5618,7 @@
         }
       ],
       "meta": {
-        "tags": [
-          "dropdown",
-          "user",
-          "profile",
-          "avatar",
-          "radix"
-        ],
+        "tags": ["dropdown", "user", "profile", "avatar", "radix"],
         "style": 1
       }
     },
@@ -7176,13 +5632,7 @@
         }
       ],
       "meta": {
-        "tags": [
-          "dropdown",
-          "user",
-          "avatar",
-          "profile",
-          "radix"
-        ],
+        "tags": ["dropdown", "user", "avatar", "profile", "radix"],
         "style": 1
       }
     },
@@ -7196,11 +5646,7 @@
         }
       ],
       "meta": {
-        "tags": [
-          "dropdown",
-          "info",
-          "radix"
-        ],
+        "tags": ["dropdown", "info", "radix"],
         "style": 1
       }
     },
@@ -7214,11 +5660,7 @@
         }
       ],
       "meta": {
-        "tags": [
-          "dropdown",
-          "text editor",
-          "radix"
-        ],
+        "tags": ["dropdown", "text editor", "radix"],
         "style": 1
       }
     },
@@ -7232,11 +5674,7 @@
         }
       ],
       "meta": {
-        "tags": [
-          "dropdown",
-          "darkmode",
-          "radix"
-        ],
+        "tags": ["dropdown", "darkmode", "radix"],
         "style": 1
       }
     },
@@ -7250,11 +5688,7 @@
         }
       ],
       "meta": {
-        "tags": [
-          "popover",
-          "filter",
-          "radix"
-        ],
+        "tags": ["popover", "filter", "radix"],
         "style": 1
       }
     },
@@ -7268,11 +5702,7 @@
         }
       ],
       "meta": {
-        "tags": [
-          "popover",
-          "notification",
-          "radix"
-        ],
+        "tags": ["popover", "notification", "radix"],
         "style": 1
       }
     },
@@ -7286,12 +5716,7 @@
         }
       ],
       "meta": {
-        "tags": [
-          "popover",
-          "notification",
-          "user",
-          "radix"
-        ],
+        "tags": ["popover", "notification", "user", "radix"],
         "style": 1
       }
     },
@@ -7305,11 +5730,7 @@
         }
       ],
       "meta": {
-        "tags": [
-          "popover",
-          "tooltip",
-          "radix"
-        ],
+        "tags": ["popover", "tooltip", "radix"],
         "style": 1
       }
     },
@@ -7323,11 +5744,7 @@
         }
       ],
       "meta": {
-        "tags": [
-          "popover",
-          "tooltip",
-          "radix"
-        ],
+        "tags": ["popover", "tooltip", "radix"],
         "style": 1
       }
     },
@@ -7341,11 +5758,7 @@
         }
       ],
       "meta": {
-        "tags": [
-          "popover",
-          "tooltip",
-          "radix"
-        ],
+        "tags": ["popover", "tooltip", "radix"],
         "style": 1
       }
     },
@@ -7359,13 +5772,7 @@
         }
       ],
       "meta": {
-        "tags": [
-          "popover",
-          "share",
-          "social",
-          "copy",
-          "radix"
-        ],
+        "tags": ["popover", "share", "social", "copy", "radix"],
         "style": 1
       }
     },
@@ -7379,12 +5786,7 @@
         }
       ],
       "meta": {
-        "tags": [
-          "popover",
-          "feedback",
-          "form",
-          "radix"
-        ],
+        "tags": ["popover", "feedback", "form", "radix"],
         "style": 1
       }
     },
@@ -7398,11 +5800,7 @@
         }
       ],
       "meta": {
-        "tags": [
-          "popover",
-          "tour",
-          "radix"
-        ],
+        "tags": ["popover", "tour", "radix"],
         "style": 1
       }
     },
@@ -7416,11 +5814,7 @@
         }
       ],
       "meta": {
-        "tags": [
-          "avatar",
-          "user",
-          "profile"
-        ],
+        "tags": ["avatar", "user", "profile"],
         "style": 1
       }
     },
@@ -7434,11 +5828,7 @@
         }
       ],
       "meta": {
-        "tags": [
-          "avatar",
-          "user",
-          "profile"
-        ],
+        "tags": ["avatar", "user", "profile"],
         "style": 1
       }
     },
@@ -7452,11 +5842,7 @@
         }
       ],
       "meta": {
-        "tags": [
-          "avatar",
-          "user",
-          "profile"
-        ],
+        "tags": ["avatar", "user", "profile"],
         "style": 1
       }
     },
@@ -7470,11 +5856,7 @@
         }
       ],
       "meta": {
-        "tags": [
-          "avatar",
-          "user",
-          "profile"
-        ],
+        "tags": ["avatar", "user", "profile"],
         "style": 1
       }
     },
@@ -7488,12 +5870,7 @@
         }
       ],
       "meta": {
-        "tags": [
-          "avatar",
-          "user",
-          "profile",
-          "status"
-        ],
+        "tags": ["avatar", "user", "profile", "status"],
         "style": 1
       }
     },
@@ -7507,12 +5884,7 @@
         }
       ],
       "meta": {
-        "tags": [
-          "avatar",
-          "user",
-          "profile",
-          "status"
-        ],
+        "tags": ["avatar", "user", "profile", "status"],
         "style": 1
       }
     },
@@ -7526,12 +5898,7 @@
         }
       ],
       "meta": {
-        "tags": [
-          "avatar",
-          "user",
-          "profile",
-          "status"
-        ],
+        "tags": ["avatar", "user", "profile", "status"],
         "style": 1
       }
     },
@@ -7545,13 +5912,7 @@
         }
       ],
       "meta": {
-        "tags": [
-          "avatar",
-          "user",
-          "profile",
-          "badge",
-          "chip"
-        ],
+        "tags": ["avatar", "user", "profile", "badge", "chip"],
         "style": 1
       }
     },
@@ -7565,13 +5926,7 @@
         }
       ],
       "meta": {
-        "tags": [
-          "avatar",
-          "user",
-          "profile",
-          "badge",
-          "chip"
-        ],
+        "tags": ["avatar", "user", "profile", "badge", "chip"],
         "style": 1
       }
     },
@@ -7585,13 +5940,7 @@
         }
       ],
       "meta": {
-        "tags": [
-          "avatar",
-          "user",
-          "profile",
-          "badge",
-          "chip"
-        ],
+        "tags": ["avatar", "user", "profile", "badge", "chip"],
         "style": 1
       }
     },
@@ -7605,11 +5954,7 @@
         }
       ],
       "meta": {
-        "tags": [
-          "avatar",
-          "user",
-          "profile"
-        ],
+        "tags": ["avatar", "user", "profile"],
         "style": 1
       }
     },
@@ -7623,10 +5968,7 @@
         }
       ],
       "meta": {
-        "tags": [
-          "avatar",
-          "avatar group"
-        ],
+        "tags": ["avatar", "avatar group"],
         "style": 1
       }
     },
@@ -7640,10 +5982,7 @@
         }
       ],
       "meta": {
-        "tags": [
-          "avatar",
-          "avatar group"
-        ],
+        "tags": ["avatar", "avatar group"],
         "style": 1
       }
     },
@@ -7657,10 +5996,7 @@
         }
       ],
       "meta": {
-        "tags": [
-          "avatar",
-          "avatar group"
-        ],
+        "tags": ["avatar", "avatar group"],
         "style": 1
       }
     },
@@ -7674,10 +6010,7 @@
         }
       ],
       "meta": {
-        "tags": [
-          "avatar",
-          "avatar group"
-        ],
+        "tags": ["avatar", "avatar group"],
         "style": 1
       }
     },
@@ -7691,10 +6024,7 @@
         }
       ],
       "meta": {
-        "tags": [
-          "avatar",
-          "avatar group"
-        ],
+        "tags": ["avatar", "avatar group"],
         "style": 1
       }
     },
@@ -7708,10 +6038,7 @@
         }
       ],
       "meta": {
-        "tags": [
-          "avatar",
-          "avatar group"
-        ],
+        "tags": ["avatar", "avatar group"],
         "style": 1
       }
     },
@@ -7725,10 +6052,7 @@
         }
       ],
       "meta": {
-        "tags": [
-          "avatar",
-          "avatar group"
-        ],
+        "tags": ["avatar", "avatar group"],
         "style": 1
       }
     },
@@ -7742,10 +6066,7 @@
         }
       ],
       "meta": {
-        "tags": [
-          "avatar",
-          "avatar group"
-        ],
+        "tags": ["avatar", "avatar group"],
         "style": 1
       }
     },
@@ -7759,10 +6080,7 @@
         }
       ],
       "meta": {
-        "tags": [
-          "avatar",
-          "avatar group"
-        ],
+        "tags": ["avatar", "avatar group"],
         "style": 1
       }
     },
@@ -7776,10 +6094,7 @@
         }
       ],
       "meta": {
-        "tags": [
-          "avatar",
-          "avatar group"
-        ],
+        "tags": ["avatar", "avatar group"],
         "style": 1
       }
     },
@@ -7793,10 +6108,7 @@
         }
       ],
       "meta": {
-        "tags": [
-          "avatar",
-          "avatar group"
-        ],
+        "tags": ["avatar", "avatar group"],
         "style": 1
       }
     },
@@ -7810,10 +6122,7 @@
         }
       ],
       "meta": {
-        "tags": [
-          "avatar",
-          "avatar group"
-        ],
+        "tags": ["avatar", "avatar group"],
         "style": 1
       }
     },
@@ -7827,10 +6136,7 @@
         }
       ],
       "meta": {
-        "tags": [
-          "badge",
-          "chip"
-        ],
+        "tags": ["badge", "chip"],
         "style": 1
       }
     },
@@ -7844,10 +6150,7 @@
         }
       ],
       "meta": {
-        "tags": [
-          "badge",
-          "chip"
-        ],
+        "tags": ["badge", "chip"],
         "style": 1
       }
     },
@@ -7861,10 +6164,7 @@
         }
       ],
       "meta": {
-        "tags": [
-          "badge",
-          "chip"
-        ],
+        "tags": ["badge", "chip"],
         "style": 1
       }
     },
@@ -7878,11 +6178,7 @@
         }
       ],
       "meta": {
-        "tags": [
-          "badge",
-          "chip",
-          "counter"
-        ],
+        "tags": ["badge", "chip", "counter"],
         "style": 1
       }
     },
@@ -7896,10 +6192,7 @@
         }
       ],
       "meta": {
-        "tags": [
-          "badge",
-          "chip"
-        ],
+        "tags": ["badge", "chip"],
         "style": 1
       }
     },
@@ -7913,11 +6206,7 @@
         }
       ],
       "meta": {
-        "tags": [
-          "badge",
-          "chip",
-          "counter"
-        ],
+        "tags": ["badge", "chip", "counter"],
         "style": 1
       }
     },
@@ -7931,11 +6220,7 @@
         }
       ],
       "meta": {
-        "tags": [
-          "badge",
-          "chip",
-          "status"
-        ],
+        "tags": ["badge", "chip", "status"],
         "style": 1
       }
     },
@@ -7949,11 +6234,7 @@
         }
       ],
       "meta": {
-        "tags": [
-          "badge",
-          "chip",
-          "status"
-        ],
+        "tags": ["badge", "chip", "status"],
         "style": 1
       }
     },
@@ -7967,11 +6248,7 @@
         }
       ],
       "meta": {
-        "tags": [
-          "badge",
-          "chip",
-          "status"
-        ],
+        "tags": ["badge", "chip", "status"],
         "style": 1
       }
     },
@@ -7985,11 +6262,7 @@
         }
       ],
       "meta": {
-        "tags": [
-          "badge",
-          "chip",
-          "status"
-        ],
+        "tags": ["badge", "chip", "status"],
         "style": 1
       }
     },
@@ -8003,11 +6276,7 @@
         }
       ],
       "meta": {
-        "tags": [
-          "badge",
-          "chip",
-          "checkbox"
-        ],
+        "tags": ["badge", "chip", "checkbox"],
         "style": 1
       }
     },
@@ -8021,10 +6290,7 @@
         }
       ],
       "meta": {
-        "tags": [
-          "badge",
-          "chip"
-        ],
+        "tags": ["badge", "chip"],
         "style": 1
       }
     },
@@ -8038,11 +6304,7 @@
         }
       ],
       "meta": {
-        "tags": [
-          "badge",
-          "chip",
-          "tag"
-        ],
+        "tags": ["badge", "chip", "tag"],
         "style": 1
       }
     },
@@ -8056,10 +6318,7 @@
         }
       ],
       "meta": {
-        "tags": [
-          "tabs",
-          "radix"
-        ],
+        "tags": ["tabs", "radix"],
         "colSpan": 2,
         "style": 2
       }
@@ -8074,10 +6333,7 @@
         }
       ],
       "meta": {
-        "tags": [
-          "tabs",
-          "radix"
-        ],
+        "tags": ["tabs", "radix"],
         "colSpan": 2,
         "style": 2
       }
@@ -8092,10 +6348,7 @@
         }
       ],
       "meta": {
-        "tags": [
-          "tabs",
-          "radix"
-        ],
+        "tags": ["tabs", "radix"],
         "colSpan": 2,
         "style": 2
       }
@@ -8110,10 +6363,7 @@
         }
       ],
       "meta": {
-        "tags": [
-          "tabs",
-          "radix"
-        ],
+        "tags": ["tabs", "radix"],
         "colSpan": 2,
         "style": 2
       }
@@ -8128,10 +6378,7 @@
         }
       ],
       "meta": {
-        "tags": [
-          "tabs",
-          "radix"
-        ],
+        "tags": ["tabs", "radix"],
         "colSpan": 2,
         "style": 2
       }
@@ -8146,10 +6393,7 @@
         }
       ],
       "meta": {
-        "tags": [
-          "tabs",
-          "radix"
-        ],
+        "tags": ["tabs", "radix"],
         "colSpan": 2,
         "style": 2
       }
@@ -8164,10 +6408,7 @@
         }
       ],
       "meta": {
-        "tags": [
-          "tabs",
-          "radix"
-        ],
+        "tags": ["tabs", "radix"],
         "colSpan": 2,
         "style": 2
       }
@@ -8182,10 +6423,7 @@
         }
       ],
       "meta": {
-        "tags": [
-          "tabs",
-          "radix"
-        ],
+        "tags": ["tabs", "radix"],
         "colSpan": 2,
         "style": 2
       }
@@ -8200,10 +6438,7 @@
         }
       ],
       "meta": {
-        "tags": [
-          "tabs",
-          "radix"
-        ],
+        "tags": ["tabs", "radix"],
         "colSpan": 2,
         "style": 2
       }
@@ -8218,10 +6453,7 @@
         }
       ],
       "meta": {
-        "tags": [
-          "tabs",
-          "radix"
-        ],
+        "tags": ["tabs", "radix"],
         "colSpan": 2,
         "style": 2
       }
@@ -8236,10 +6468,7 @@
         }
       ],
       "meta": {
-        "tags": [
-          "tabs",
-          "radix"
-        ],
+        "tags": ["tabs", "radix"],
         "colSpan": 2,
         "style": 2
       }
@@ -8254,10 +6483,7 @@
         }
       ],
       "meta": {
-        "tags": [
-          "tabs",
-          "radix"
-        ],
+        "tags": ["tabs", "radix"],
         "colSpan": 2,
         "style": 2
       }
@@ -8272,10 +6498,7 @@
         }
       ],
       "meta": {
-        "tags": [
-          "tabs",
-          "radix"
-        ],
+        "tags": ["tabs", "radix"],
         "colSpan": 2,
         "style": 2
       }
@@ -8290,10 +6513,7 @@
         }
       ],
       "meta": {
-        "tags": [
-          "tabs",
-          "radix"
-        ],
+        "tags": ["tabs", "radix"],
         "colSpan": 2,
         "style": 2
       }
@@ -8308,10 +6528,7 @@
         }
       ],
       "meta": {
-        "tags": [
-          "tabs",
-          "radix"
-        ],
+        "tags": ["tabs", "radix"],
         "colSpan": 2,
         "style": 2
       }
@@ -8326,10 +6543,7 @@
         }
       ],
       "meta": {
-        "tags": [
-          "tabs",
-          "radix"
-        ],
+        "tags": ["tabs", "radix"],
         "colSpan": 2,
         "style": 2
       }
@@ -8344,11 +6558,7 @@
         }
       ],
       "meta": {
-        "tags": [
-          "tabs",
-          "vertical tabs",
-          "radix"
-        ],
+        "tags": ["tabs", "vertical tabs", "radix"],
         "colSpan": 2,
         "style": 2
       }
@@ -8363,11 +6573,7 @@
         }
       ],
       "meta": {
-        "tags": [
-          "tabs",
-          "vertical tabs",
-          "radix"
-        ],
+        "tags": ["tabs", "vertical tabs", "radix"],
         "colSpan": 2,
         "style": 2
       }
@@ -8382,11 +6588,7 @@
         }
       ],
       "meta": {
-        "tags": [
-          "tabs",
-          "vertical tabs",
-          "radix"
-        ],
+        "tags": ["tabs", "vertical tabs", "radix"],
         "colSpan": 2,
         "style": 2
       }
@@ -8401,11 +6603,7 @@
         }
       ],
       "meta": {
-        "tags": [
-          "tabs",
-          "vertical tabs",
-          "radix"
-        ],
+        "tags": ["tabs", "vertical tabs", "radix"],
         "colSpan": 2,
         "style": 2
       }
@@ -8420,10 +6618,7 @@
         }
       ],
       "meta": {
-        "tags": [
-          "breadcrumb",
-          "radix"
-        ],
+        "tags": ["breadcrumb", "radix"],
         "colSpan": 2,
         "style": 1
       }
@@ -8438,11 +6633,7 @@
         }
       ],
       "meta": {
-        "tags": [
-          "breadcrumb",
-          "dropdown",
-          "radix"
-        ],
+        "tags": ["breadcrumb", "dropdown", "radix"],
         "colSpan": 2,
         "style": 1
       }
@@ -8457,10 +6648,7 @@
         }
       ],
       "meta": {
-        "tags": [
-          "breadcrumb",
-          "radix"
-        ],
+        "tags": ["breadcrumb", "radix"],
         "colSpan": 2,
         "style": 1
       }
@@ -8475,10 +6663,7 @@
         }
       ],
       "meta": {
-        "tags": [
-          "breadcrumb",
-          "radix"
-        ],
+        "tags": ["breadcrumb", "radix"],
         "colSpan": 2,
         "style": 1
       }
@@ -8493,10 +6678,7 @@
         }
       ],
       "meta": {
-        "tags": [
-          "breadcrumb",
-          "radix"
-        ],
+        "tags": ["breadcrumb", "radix"],
         "colSpan": 2,
         "style": 1
       }
@@ -8511,10 +6693,7 @@
         }
       ],
       "meta": {
-        "tags": [
-          "breadcrumb",
-          "radix"
-        ],
+        "tags": ["breadcrumb", "radix"],
         "colSpan": 2,
         "style": 1
       }
@@ -8529,10 +6708,7 @@
         }
       ],
       "meta": {
-        "tags": [
-          "breadcrumb",
-          "radix"
-        ],
+        "tags": ["breadcrumb", "radix"],
         "colSpan": 2,
         "style": 1
       }
@@ -8547,11 +6723,7 @@
         }
       ],
       "meta": {
-        "tags": [
-          "breadcrumb",
-          "select",
-          "radix"
-        ],
+        "tags": ["breadcrumb", "select", "radix"],
         "colSpan": 2,
         "style": 1
       }
@@ -8566,9 +6738,7 @@
         }
       ],
       "meta": {
-        "tags": [
-          "pagination"
-        ],
+        "tags": ["pagination"],
         "colSpan": 2
       }
     },
@@ -8582,9 +6752,7 @@
         }
       ],
       "meta": {
-        "tags": [
-          "pagination"
-        ],
+        "tags": ["pagination"],
         "colSpan": 2
       }
     },
@@ -8598,9 +6766,7 @@
         }
       ],
       "meta": {
-        "tags": [
-          "pagination"
-        ],
+        "tags": ["pagination"],
         "colSpan": 2
       }
     },
@@ -8614,9 +6780,7 @@
         }
       ],
       "meta": {
-        "tags": [
-          "pagination"
-        ],
+        "tags": ["pagination"],
         "colSpan": 2
       }
     },
@@ -8630,9 +6794,7 @@
         }
       ],
       "meta": {
-        "tags": [
-          "pagination"
-        ],
+        "tags": ["pagination"],
         "colSpan": 2
       }
     },
@@ -8646,9 +6808,7 @@
         }
       ],
       "meta": {
-        "tags": [
-          "pagination"
-        ],
+        "tags": ["pagination"],
         "colSpan": 2
       }
     },
@@ -8662,9 +6822,7 @@
         }
       ],
       "meta": {
-        "tags": [
-          "pagination"
-        ],
+        "tags": ["pagination"],
         "colSpan": 2
       }
     },
@@ -8678,9 +6836,7 @@
         }
       ],
       "meta": {
-        "tags": [
-          "pagination"
-        ],
+        "tags": ["pagination"],
         "colSpan": 2
       }
     },
@@ -8694,9 +6850,7 @@
         }
       ],
       "meta": {
-        "tags": [
-          "pagination"
-        ],
+        "tags": ["pagination"],
         "colSpan": 2
       }
     },
@@ -8710,11 +6864,7 @@
         }
       ],
       "meta": {
-        "tags": [
-          "pagination",
-          "select",
-          "radix"
-        ],
+        "tags": ["pagination", "select", "radix"],
         "colSpan": 2
       }
     },
@@ -8728,11 +6878,7 @@
         }
       ],
       "meta": {
-        "tags": [
-          "pagination",
-          "select",
-          "radix"
-        ],
+        "tags": ["pagination", "select", "radix"],
         "colSpan": 2
       }
     },
@@ -8746,10 +6892,7 @@
         }
       ],
       "meta": {
-        "tags": [
-          "pagination",
-          "input"
-        ],
+        "tags": ["pagination", "input"],
         "colSpan": 2
       }
     },
@@ -8763,9 +6906,7 @@
         }
       ],
       "meta": {
-        "tags": [
-          "table"
-        ],
+        "tags": ["table"],
         "colSpan": 3
       }
     },
@@ -8779,11 +6920,7 @@
         }
       ],
       "meta": {
-        "tags": [
-          "table",
-          "user",
-          "avatar"
-        ],
+        "tags": ["table", "user", "avatar"],
         "colSpan": 3
       }
     },
@@ -8797,9 +6934,7 @@
         }
       ],
       "meta": {
-        "tags": [
-          "table"
-        ],
+        "tags": ["table"],
         "colSpan": 3
       }
     },
@@ -8813,9 +6948,7 @@
         }
       ],
       "meta": {
-        "tags": [
-          "table"
-        ],
+        "tags": ["table"],
         "colSpan": 3
       }
     },
@@ -8829,9 +6962,7 @@
         }
       ],
       "meta": {
-        "tags": [
-          "table"
-        ],
+        "tags": ["table"],
         "colSpan": 3
       }
     },
@@ -8845,9 +6976,7 @@
         }
       ],
       "meta": {
-        "tags": [
-          "table"
-        ],
+        "tags": ["table"],
         "colSpan": 3
       }
     },
@@ -8861,10 +6990,7 @@
         }
       ],
       "meta": {
-        "tags": [
-          "table",
-          "checkbox"
-        ],
+        "tags": ["table", "checkbox"],
         "colSpan": 3
       }
     },
@@ -8878,11 +7004,7 @@
         }
       ],
       "meta": {
-        "tags": [
-          "table",
-          "checkbox",
-          "card"
-        ],
+        "tags": ["table", "checkbox", "card"],
         "colSpan": 3
       }
     },
@@ -8896,10 +7018,7 @@
         }
       ],
       "meta": {
-        "tags": [
-          "table",
-          "vertical table"
-        ],
+        "tags": ["table", "vertical table"],
         "colSpan": 3
       }
     },
@@ -8913,10 +7032,7 @@
         }
       ],
       "meta": {
-        "tags": [
-          "table",
-          "sticky"
-        ],
+        "tags": ["table", "sticky"],
         "colSpan": 3
       }
     },
@@ -8930,9 +7046,7 @@
         }
       ],
       "meta": {
-        "tags": [
-          "table"
-        ],
+        "tags": ["table"],
         "colSpan": 3
       }
     },
@@ -8946,14 +7060,7 @@
         }
       ],
       "meta": {
-        "tags": [
-          "table",
-          "tanstack",
-          "checkbox",
-          "badge",
-          "chip",
-          "flag"
-        ],
+        "tags": ["table", "tanstack", "checkbox", "badge", "chip", "flag"],
         "colSpan": 3
       }
     },
@@ -8991,13 +7098,7 @@
         }
       ],
       "meta": {
-        "tags": [
-          "table",
-          "tanstack",
-          "flag",
-          "sort",
-          "resize"
-        ],
+        "tags": ["table", "tanstack", "flag", "sort", "resize"],
         "colSpan": 3
       }
     },
@@ -9011,13 +7112,7 @@
         }
       ],
       "meta": {
-        "tags": [
-          "table",
-          "tanstack",
-          "flag",
-          "sticky",
-          "resize"
-        ],
+        "tags": ["table", "tanstack", "flag", "sticky", "resize"],
         "colSpan": 3
       }
     },
@@ -9031,13 +7126,7 @@
         }
       ],
       "meta": {
-        "tags": [
-          "table",
-          "tanstack",
-          "flag",
-          "sort",
-          "drag and drop"
-        ],
+        "tags": ["table", "tanstack", "flag", "sort", "drag and drop"],
         "colSpan": 3
       }
     },
@@ -9051,15 +7140,7 @@
         }
       ],
       "meta": {
-        "tags": [
-          "table",
-          "tanstack",
-          "checkbox",
-          "collapsible",
-          "flag",
-          "badge",
-          "chip"
-        ],
+        "tags": ["table", "tanstack", "checkbox", "collapsible", "flag", "badge", "chip"],
         "colSpan": 3
       }
     },
@@ -9073,16 +7154,7 @@
         }
       ],
       "meta": {
-        "tags": [
-          "table",
-          "tanstack",
-          "checkbox",
-          "sort",
-          "flag",
-          "badge",
-          "chip",
-          "pagination"
-        ],
+        "tags": ["table", "tanstack", "checkbox", "sort", "flag", "badge", "chip", "pagination"],
         "colSpan": 3
       }
     },
@@ -9096,16 +7168,7 @@
         }
       ],
       "meta": {
-        "tags": [
-          "table",
-          "tanstack",
-          "checkbox",
-          "sort",
-          "flag",
-          "badge",
-          "chip",
-          "pagination"
-        ],
+        "tags": ["table", "tanstack", "checkbox", "sort", "flag", "badge", "chip", "pagination"],
         "colSpan": 3
       }
     },
@@ -9144,11 +7207,7 @@
         }
       ],
       "meta": {
-        "tags": [
-          "input",
-          "label",
-          "range"
-        ]
+        "tags": ["input", "label", "range"]
       }
     },
     {
@@ -9161,11 +7220,7 @@
         }
       ],
       "meta": {
-        "tags": [
-          "calendar",
-          "date",
-          "react aria"
-        ],
+        "tags": ["calendar", "date", "react aria"],
         "style": 1
       }
     },
@@ -9179,12 +7234,7 @@
         }
       ],
       "meta": {
-        "tags": [
-          "calendar",
-          "range calendar",
-          "date",
-          "react aria"
-        ],
+        "tags": ["calendar", "range calendar", "date", "react aria"],
         "style": 1
       }
     },
@@ -9198,13 +7248,7 @@
         }
       ],
       "meta": {
-        "tags": [
-          "calendar",
-          "range calendar",
-          "date",
-          "disabled",
-          "react aria"
-        ],
+        "tags": ["calendar", "range calendar", "date", "disabled", "react aria"],
         "style": 1
       }
     },
@@ -9218,11 +7262,7 @@
         }
       ],
       "meta": {
-        "tags": [
-          "calendar",
-          "date",
-          "react daypicker"
-        ],
+        "tags": ["calendar", "date", "react daypicker"],
         "style": 1
       }
     },
@@ -9236,12 +7276,7 @@
         }
       ],
       "meta": {
-        "tags": [
-          "calendar",
-          "range calendar",
-          "date",
-          "react daypicker"
-        ],
+        "tags": ["calendar", "range calendar", "date", "react daypicker"],
         "style": 1
       }
     },
@@ -9255,13 +7290,7 @@
         }
       ],
       "meta": {
-        "tags": [
-          "calendar",
-          "range calendar",
-          "date",
-          "disabled",
-          "react daypicker"
-        ],
+        "tags": ["calendar", "range calendar", "date", "disabled", "react daypicker"],
         "style": 1
       }
     },
@@ -9275,11 +7304,7 @@
         }
       ],
       "meta": {
-        "tags": [
-          "calendar",
-          "date",
-          "react daypicker"
-        ],
+        "tags": ["calendar", "date", "react daypicker"],
         "style": 1
       }
     },
@@ -9293,11 +7318,7 @@
         }
       ],
       "meta": {
-        "tags": [
-          "calendar",
-          "date",
-          "react daypicker"
-        ],
+        "tags": ["calendar", "date", "react daypicker"],
         "style": 1
       }
     },
@@ -9311,12 +7332,7 @@
         }
       ],
       "meta": {
-        "tags": [
-          "calendar",
-          "range calendar",
-          "date",
-          "react daypicker"
-        ],
+        "tags": ["calendar", "range calendar", "date", "react daypicker"],
         "style": 1
       }
     },
@@ -9330,11 +7346,7 @@
         }
       ],
       "meta": {
-        "tags": [
-          "calendar",
-          "date",
-          "react daypicker"
-        ],
+        "tags": ["calendar", "date", "react daypicker"],
         "style": 1
       }
     },
@@ -9348,11 +7360,7 @@
         }
       ],
       "meta": {
-        "tags": [
-          "calendar",
-          "date",
-          "react daypicker"
-        ],
+        "tags": ["calendar", "date", "react daypicker"],
         "style": 1
       }
     },
@@ -9366,11 +7374,7 @@
         }
       ],
       "meta": {
-        "tags": [
-          "calendar",
-          "date",
-          "react daypicker"
-        ],
+        "tags": ["calendar", "date", "react daypicker"],
         "style": 1
       }
     },
@@ -9384,12 +7388,7 @@
         }
       ],
       "meta": {
-        "tags": [
-          "calendar",
-          "date",
-          "week",
-          "react daypicker"
-        ],
+        "tags": ["calendar", "date", "week", "react daypicker"],
         "style": 1
       }
     },
@@ -9403,12 +7402,7 @@
         }
       ],
       "meta": {
-        "tags": [
-          "calendar",
-          "date",
-          "button",
-          "react daypicker"
-        ],
+        "tags": ["calendar", "date", "button", "react daypicker"],
         "style": 1
       }
     },
@@ -9422,12 +7416,7 @@
         }
       ],
       "meta": {
-        "tags": [
-          "calendar",
-          "date",
-          "button",
-          "react daypicker"
-        ],
+        "tags": ["calendar", "date", "button", "react daypicker"],
         "style": 1
       }
     },
@@ -9441,12 +7430,7 @@
         }
       ],
       "meta": {
-        "tags": [
-          "calendar",
-          "date",
-          "input",
-          "react daypicker"
-        ],
+        "tags": ["calendar", "date", "input", "react daypicker"],
         "style": 1
       }
     },
@@ -9460,13 +7444,7 @@
         }
       ],
       "meta": {
-        "tags": [
-          "calendar",
-          "date",
-          "input",
-          "time",
-          "react daypicker"
-        ],
+        "tags": ["calendar", "date", "input", "time", "react daypicker"],
         "style": 1
       }
     },
@@ -9480,13 +7458,7 @@
         }
       ],
       "meta": {
-        "tags": [
-          "calendar",
-          "date",
-          "collapsible",
-          "react daypicker",
-          "radix"
-        ],
+        "tags": ["calendar", "date", "collapsible", "react daypicker", "radix"],
         "style": 1
       }
     },
@@ -9500,13 +7472,7 @@
         }
       ],
       "meta": {
-        "tags": [
-          "calendar",
-          "date",
-          "time",
-          "button",
-          "react daypicker"
-        ],
+        "tags": ["calendar", "date", "time", "button", "react daypicker"],
         "colSpan": 3,
         "style": 1
       }
@@ -9521,12 +7487,7 @@
         }
       ],
       "meta": {
-        "tags": [
-          "calendar",
-          "date",
-          "button",
-          "react daypicker"
-        ],
+        "tags": ["calendar", "date", "button", "react daypicker"],
         "colSpan": 3,
         "style": 1
       }
@@ -9541,13 +7502,7 @@
         }
       ],
       "meta": {
-        "tags": [
-          "calendar",
-          "range calendar",
-          "date",
-          "button",
-          "react daypicker"
-        ],
+        "tags": ["calendar", "range calendar", "date", "button", "react daypicker"],
         "colSpan": 3,
         "style": 1
       }
@@ -9562,12 +7517,7 @@
         }
       ],
       "meta": {
-        "tags": [
-          "calendar",
-          "range calendar",
-          "date",
-          "react daypicker"
-        ],
+        "tags": ["calendar", "range calendar", "date", "react daypicker"],
         "colSpan": 3,
         "style": 1
       }
@@ -9582,12 +7532,7 @@
         }
       ],
       "meta": {
-        "tags": [
-          "calendar",
-          "range calendar",
-          "date",
-          "react daypicker"
-        ],
+        "tags": ["calendar", "range calendar", "date", "react daypicker"],
         "colSpan": 3,
         "style": 1
       }
@@ -9602,11 +7547,7 @@
         }
       ],
       "meta": {
-        "tags": [
-          "calendar",
-          "date",
-          "react daypicker"
-        ],
+        "tags": ["calendar", "date", "react daypicker"],
         "colSpan": 3,
         "style": 1
       }
@@ -9621,13 +7562,7 @@
         }
       ],
       "meta": {
-        "tags": [
-          "calendar",
-          "date",
-          "button",
-          "picker",
-          "react daypicker"
-        ]
+        "tags": ["calendar", "date", "button", "picker", "react daypicker"]
       }
     },
     {
@@ -9640,13 +7575,7 @@
         }
       ],
       "meta": {
-        "tags": [
-          "calendar",
-          "date",
-          "button",
-          "picker",
-          "react daypicker"
-        ]
+        "tags": ["calendar", "date", "button", "picker", "react daypicker"]
       }
     },
     {
@@ -9659,9 +7588,7 @@
         }
       ],
       "meta": {
-        "tags": [
-          "stepper"
-        ],
+        "tags": ["stepper"],
         "colSpan": 3
       }
     },
@@ -9675,9 +7602,7 @@
         }
       ],
       "meta": {
-        "tags": [
-          "stepper"
-        ],
+        "tags": ["stepper"],
         "colSpan": 3
       }
     },
@@ -9691,9 +7616,7 @@
         }
       ],
       "meta": {
-        "tags": [
-          "stepper"
-        ],
+        "tags": ["stepper"],
         "colSpan": 3
       }
     },
@@ -9707,9 +7630,7 @@
         }
       ],
       "meta": {
-        "tags": [
-          "stepper"
-        ],
+        "tags": ["stepper"],
         "colSpan": 3
       }
     },
@@ -9723,9 +7644,7 @@
         }
       ],
       "meta": {
-        "tags": [
-          "stepper"
-        ],
+        "tags": ["stepper"],
         "colSpan": 3
       }
     },
@@ -9739,9 +7658,7 @@
         }
       ],
       "meta": {
-        "tags": [
-          "stepper"
-        ],
+        "tags": ["stepper"],
         "colSpan": 3
       }
     },
@@ -9755,9 +7672,7 @@
         }
       ],
       "meta": {
-        "tags": [
-          "stepper"
-        ],
+        "tags": ["stepper"],
         "colSpan": 3
       }
     },
@@ -9771,9 +7686,7 @@
         }
       ],
       "meta": {
-        "tags": [
-          "stepper"
-        ],
+        "tags": ["stepper"],
         "colSpan": 3
       }
     },
@@ -9787,9 +7700,7 @@
         }
       ],
       "meta": {
-        "tags": [
-          "stepper"
-        ],
+        "tags": ["stepper"],
         "colSpan": 3
       }
     },
@@ -9803,9 +7714,7 @@
         }
       ],
       "meta": {
-        "tags": [
-          "stepper"
-        ],
+        "tags": ["stepper"],
         "colSpan": 3
       }
     },
@@ -9819,9 +7728,7 @@
         }
       ],
       "meta": {
-        "tags": [
-          "stepper"
-        ],
+        "tags": ["stepper"],
         "colSpan": 3
       }
     },
@@ -9835,9 +7742,7 @@
         }
       ],
       "meta": {
-        "tags": [
-          "stepper"
-        ],
+        "tags": ["stepper"],
         "colSpan": 3
       }
     },
@@ -9851,9 +7756,7 @@
         }
       ],
       "meta": {
-        "tags": [
-          "stepper"
-        ],
+        "tags": ["stepper"],
         "colSpan": 3
       }
     },
@@ -9867,10 +7770,7 @@
         }
       ],
       "meta": {
-        "tags": [
-          "stepper",
-          "vertical stepper"
-        ],
+        "tags": ["stepper", "vertical stepper"],
         "colSpan": 2
       }
     },
@@ -9884,10 +7784,7 @@
         }
       ],
       "meta": {
-        "tags": [
-          "stepper",
-          "vertical stepper"
-        ],
+        "tags": ["stepper", "vertical stepper"],
         "colSpan": 2
       }
     },
@@ -9901,10 +7798,7 @@
         }
       ],
       "meta": {
-        "tags": [
-          "stepper",
-          "vertical stepper"
-        ],
+        "tags": ["stepper", "vertical stepper"],
         "colSpan": 2
       }
     },
@@ -9918,10 +7812,7 @@
         }
       ],
       "meta": {
-        "tags": [
-          "stepper",
-          "vertical stepper"
-        ],
+        "tags": ["stepper", "vertical stepper"],
         "colSpan": 2
       }
     },
@@ -9935,10 +7826,7 @@
         }
       ],
       "meta": {
-        "tags": [
-          "timeline",
-          "vertical timeline"
-        ],
+        "tags": ["timeline", "vertical timeline"],
         "colSpan": 2
       }
     },
@@ -9952,10 +7840,7 @@
         }
       ],
       "meta": {
-        "tags": [
-          "timeline",
-          "vertical timeline"
-        ],
+        "tags": ["timeline", "vertical timeline"],
         "colSpan": 2
       }
     },
@@ -9969,10 +7854,7 @@
         }
       ],
       "meta": {
-        "tags": [
-          "timeline",
-          "vertical timeline"
-        ],
+        "tags": ["timeline", "vertical timeline"],
         "colSpan": 2
       }
     },
@@ -9986,10 +7868,7 @@
         }
       ],
       "meta": {
-        "tags": [
-          "timeline",
-          "vertical timeline"
-        ],
+        "tags": ["timeline", "vertical timeline"],
         "colSpan": 2
       }
     },
@@ -10003,10 +7882,7 @@
         }
       ],
       "meta": {
-        "tags": [
-          "timeline",
-          "vertical timeline"
-        ],
+        "tags": ["timeline", "vertical timeline"],
         "colSpan": 2
       }
     },
@@ -10020,10 +7896,7 @@
         }
       ],
       "meta": {
-        "tags": [
-          "timeline",
-          "vertical timeline"
-        ],
+        "tags": ["timeline", "vertical timeline"],
         "colSpan": 2
       }
     },
@@ -10037,10 +7910,7 @@
         }
       ],
       "meta": {
-        "tags": [
-          "timeline",
-          "vertical timeline"
-        ],
+        "tags": ["timeline", "vertical timeline"],
         "colSpan": 2
       }
     },
@@ -10054,10 +7924,7 @@
         }
       ],
       "meta": {
-        "tags": [
-          "timeline",
-          "vertical timeline"
-        ],
+        "tags": ["timeline", "vertical timeline"],
         "colSpan": 2
       }
     },
@@ -10071,10 +7938,7 @@
         }
       ],
       "meta": {
-        "tags": [
-          "timeline",
-          "vertical timeline"
-        ],
+        "tags": ["timeline", "vertical timeline"],
         "colSpan": 2
       }
     },
@@ -10088,10 +7952,7 @@
         }
       ],
       "meta": {
-        "tags": [
-          "timeline",
-          "vertical timeline"
-        ],
+        "tags": ["timeline", "vertical timeline"],
         "colSpan": 2
       }
     },
@@ -10105,9 +7966,7 @@
         }
       ],
       "meta": {
-        "tags": [
-          "timeline"
-        ],
+        "tags": ["timeline"],
         "colSpan": 3
       }
     },
@@ -10121,9 +7980,7 @@
         }
       ],
       "meta": {
-        "tags": [
-          "timeline"
-        ],
+        "tags": ["timeline"],
         "colSpan": 3
       }
     },
@@ -10137,9 +7994,7 @@
         }
       ],
       "meta": {
-        "tags": [
-          "calendar"
-        ],
+        "tags": ["calendar"],
         "colSpan": 3
       }
     },
@@ -10153,13 +8008,7 @@
         }
       ],
       "meta": {
-        "tags": [
-          "upload",
-          "file",
-          "image",
-          "drag and drop",
-          "avatar"
-        ]
+        "tags": ["upload", "file", "image", "drag and drop", "avatar"]
       }
     },
     {
@@ -10172,12 +8021,7 @@
         }
       ],
       "meta": {
-        "tags": [
-          "upload",
-          "file",
-          "image",
-          "drag and drop"
-        ],
+        "tags": ["upload", "file", "image", "drag and drop"],
         "colSpan": 2
       }
     },
@@ -10191,12 +8035,7 @@
         }
       ],
       "meta": {
-        "tags": [
-          "upload",
-          "file",
-          "image",
-          "drag and drop"
-        ],
+        "tags": ["upload", "file", "image", "drag and drop"],
         "colSpan": 2
       }
     },
@@ -10210,12 +8049,7 @@
         }
       ],
       "meta": {
-        "tags": [
-          "upload",
-          "file",
-          "image",
-          "drag and drop"
-        ],
+        "tags": ["upload", "file", "image", "drag and drop"],
         "colSpan": 2
       }
     },
@@ -10229,12 +8063,7 @@
         }
       ],
       "meta": {
-        "tags": [
-          "upload",
-          "file",
-          "image",
-          "drag and drop"
-        ],
+        "tags": ["upload", "file", "image", "drag and drop"],
         "colSpan": 2
       }
     },
@@ -10248,12 +8077,7 @@
         }
       ],
       "meta": {
-        "tags": [
-          "upload",
-          "file",
-          "image",
-          "drag and drop"
-        ],
+        "tags": ["upload", "file", "image", "drag and drop"],
         "colSpan": 2
       }
     },
@@ -10267,12 +8091,7 @@
         }
       ],
       "meta": {
-        "tags": [
-          "upload",
-          "file",
-          "image",
-          "drag and drop"
-        ],
+        "tags": ["upload", "file", "image", "drag and drop"],
         "colSpan": 2
       }
     },
@@ -10286,12 +8105,7 @@
         }
       ],
       "meta": {
-        "tags": [
-          "upload",
-          "file",
-          "image",
-          "drag and drop"
-        ],
+        "tags": ["upload", "file", "image", "drag and drop"],
         "colSpan": 2
       }
     },
@@ -10305,12 +8119,7 @@
         }
       ],
       "meta": {
-        "tags": [
-          "upload",
-          "file",
-          "image",
-          "drag and drop"
-        ],
+        "tags": ["upload", "file", "image", "drag and drop"],
         "colSpan": 2
       }
     },
@@ -10324,12 +8133,7 @@
         }
       ],
       "meta": {
-        "tags": [
-          "upload",
-          "file",
-          "image",
-          "drag and drop"
-        ],
+        "tags": ["upload", "file", "image", "drag and drop"],
         "colSpan": 2
       }
     },
@@ -10343,12 +8147,7 @@
         }
       ],
       "meta": {
-        "tags": [
-          "upload",
-          "file",
-          "image",
-          "drag and drop"
-        ],
+        "tags": ["upload", "file", "image", "drag and drop"],
         "colSpan": 2
       }
     },
@@ -10362,16 +8161,7 @@
         }
       ],
       "meta": {
-        "tags": [
-          "upload",
-          "file",
-          "image",
-          "drag and drop",
-          "crop",
-          "dialog",
-          "slider",
-          "zoom"
-        ],
+        "tags": ["upload", "file", "image", "drag and drop", "crop", "dialog", "slider", "zoom"],
         "colSpan": 3
       }
     },
@@ -10385,11 +8175,7 @@
         }
       ],
       "meta": {
-        "tags": [
-          "image",
-          "crop",
-          "zoom"
-        ],
+        "tags": ["image", "crop", "zoom"],
         "colSpan": 2
       }
     },
@@ -10403,11 +8189,7 @@
         }
       ],
       "meta": {
-        "tags": [
-          "image",
-          "crop",
-          "zoom"
-        ],
+        "tags": ["image", "crop", "zoom"],
         "colSpan": 2
       }
     },
@@ -10421,11 +8203,7 @@
         }
       ],
       "meta": {
-        "tags": [
-          "image",
-          "crop",
-          "zoom"
-        ],
+        "tags": ["image", "crop", "zoom"],
         "colSpan": 2
       }
     },
@@ -10439,11 +8217,7 @@
         }
       ],
       "meta": {
-        "tags": [
-          "image",
-          "crop",
-          "zoom"
-        ],
+        "tags": ["image", "crop", "zoom"],
         "colSpan": 2
       }
     },
@@ -10457,11 +8231,7 @@
         }
       ],
       "meta": {
-        "tags": [
-          "image",
-          "crop",
-          "zoom"
-        ],
+        "tags": ["image", "crop", "zoom"],
         "colSpan": 2
       }
     },
@@ -10475,11 +8245,7 @@
         }
       ],
       "meta": {
-        "tags": [
-          "image",
-          "crop",
-          "zoom"
-        ],
+        "tags": ["image", "crop", "zoom"],
         "colSpan": 2
       }
     },
@@ -10493,12 +8259,7 @@
         }
       ],
       "meta": {
-        "tags": [
-          "image",
-          "crop",
-          "zoom",
-          "slider"
-        ],
+        "tags": ["image", "crop", "zoom", "slider"],
         "colSpan": 2
       }
     },
@@ -10512,11 +8273,7 @@
         }
       ],
       "meta": {
-        "tags": [
-          "image",
-          "crop",
-          "zoom"
-        ],
+        "tags": ["image", "crop", "zoom"],
         "colSpan": 2
       }
     },
@@ -10530,11 +8287,7 @@
         }
       ],
       "meta": {
-        "tags": [
-          "image",
-          "crop",
-          "zoom"
-        ],
+        "tags": ["image", "crop", "zoom"],
         "colSpan": 2
       }
     },
@@ -10548,11 +8301,7 @@
         }
       ],
       "meta": {
-        "tags": [
-          "image",
-          "crop",
-          "zoom"
-        ],
+        "tags": ["image", "crop", "zoom"],
         "colSpan": 2
       }
     }

--- a/registry.json
+++ b/registry.json
@@ -6,49 +6,16 @@
     {
       "name": "accordion",
       "type": "registry:ui",
-      "dependencies": ["@radix-ui/react-accordion"],
       "files": [
         {
           "path": "registry/default/ui/accordion.tsx",
           "type": "registry:ui"
         }
-      ],
-      "tailwind": {
-        "config": {
-          "theme": {
-            "extend": {
-              "keyframes": {
-                "accordion-down": {
-                  "from": {
-                    "height": "0"
-                  },
-                  "to": {
-                    "height": "var(--radix-accordion-content-height)"
-                  }
-                },
-                "accordion-up": {
-                  "from": {
-                    "height": "var(--radix-accordion-content-height)"
-                  },
-                  "to": {
-                    "height": "0"
-                  }
-                }
-              },
-              "animation": {
-                "accordion-down": "accordion-down 0.2s ease-out",
-                "accordion-up": "accordion-up 0.2s ease-out"
-              }
-            }
-          }
-        }
-      }
+      ]
     },
     {
       "name": "alert-dialog",
       "type": "registry:ui",
-      "dependencies": ["@radix-ui/react-alert-dialog"],
-      "registryDependencies": ["https://originui.com/r/button.json"],
       "files": [
         {
           "path": "registry/default/ui/alert-dialog.tsx",
@@ -59,7 +26,6 @@
     {
       "name": "avatar",
       "type": "registry:ui",
-      "dependencies": ["@radix-ui/react-avatar"],
       "files": [
         {
           "path": "registry/default/ui/avatar.tsx",
@@ -80,7 +46,6 @@
     {
       "name": "breadcrumb",
       "type": "registry:ui",
-      "dependencies": ["@radix-ui/react-slot"],
       "files": [
         {
           "path": "registry/default/ui/breadcrumb.tsx",
@@ -91,7 +56,6 @@
     {
       "name": "button",
       "type": "registry:ui",
-      "dependencies": ["@radix-ui/react-slot"],
       "files": [
         {
           "path": "registry/default/ui/button.tsx",
@@ -102,8 +66,6 @@
     {
       "name": "calendar",
       "type": "registry:ui",
-      "dependencies": ["react-day-picker", "date-fns"],
-      "registryDependencies": ["button"],
       "files": [
         {
           "path": "registry/default/ui/calendar.tsx",
@@ -114,7 +76,6 @@
     {
       "name": "calendar-rac",
       "type": "registry:ui",
-      "dependencies": ["react-aria-components", "@internationalized/date"],
       "files": [
         {
           "path": "registry/default/ui/calendar-rac.tsx",
@@ -125,7 +86,6 @@
     {
       "name": "checkbox",
       "type": "registry:ui",
-      "dependencies": ["@radix-ui/react-checkbox"],
       "files": [
         {
           "path": "registry/default/ui/checkbox.tsx",
@@ -146,7 +106,6 @@
     {
       "name": "collapsible",
       "type": "registry:ui",
-      "dependencies": ["@radix-ui/react-collapsible"],
       "files": [
         {
           "path": "registry/default/ui/collapsible.tsx",
@@ -158,7 +117,6 @@
       "name": "command",
       "type": "registry:ui",
       "dependencies": ["cmdk@1.0.0"],
-      "registryDependencies": ["dialog"],
       "files": [
         {
           "path": "registry/default/ui/command.tsx",
@@ -169,7 +127,6 @@
     {
       "name": "datefield-rac",
       "type": "registry:ui",
-      "dependencies": ["react-aria-components"],
       "files": [
         {
           "path": "registry/default/ui/datefield-rac.tsx",
@@ -180,7 +137,6 @@
     {
       "name": "dialog",
       "type": "registry:ui",
-      "dependencies": ["@radix-ui/react-dialog"],
       "files": [
         {
           "path": "registry/default/ui/dialog.tsx",
@@ -191,7 +147,6 @@
     {
       "name": "dropdown-menu",
       "type": "registry:ui",
-      "dependencies": ["@radix-ui/react-dropdown-menu"],
       "files": [
         {
           "path": "registry/default/ui/dropdown-menu.tsx",
@@ -202,7 +157,6 @@
     {
       "name": "hover-card",
       "type": "registry:ui",
-      "dependencies": ["@radix-ui/react-hover-card"],
       "files": [
         {
           "path": "registry/default/ui/hover-card.tsx",
@@ -223,7 +177,6 @@
     {
       "name": "label",
       "type": "registry:ui",
-      "dependencies": ["@radix-ui/react-label"],
       "files": [
         {
           "path": "registry/default/ui/label.tsx",
@@ -234,7 +187,6 @@
     {
       "name": "multiselect",
       "type": "registry:ui",
-      "registryDependencies": ["https://originui.com/r/command.json"],
       "files": [
         {
           "path": "registry/default/ui/multiselect.tsx",
@@ -245,7 +197,6 @@
     {
       "name": "pagination",
       "type": "registry:ui",
-      "registryDependencies": ["button"],
       "files": [
         {
           "path": "registry/default/ui/pagination.tsx",
@@ -256,7 +207,6 @@
     {
       "name": "popover",
       "type": "registry:ui",
-      "dependencies": ["@radix-ui/react-popover"],
       "files": [
         {
           "path": "registry/default/ui/popover.tsx",
@@ -267,7 +217,6 @@
     {
       "name": "progress",
       "type": "registry:ui",
-      "dependencies": ["@radix-ui/react-progress"],
       "files": [
         {
           "path": "registry/default/ui/progress.tsx",
@@ -278,7 +227,6 @@
     {
       "name": "radio-group",
       "type": "registry:ui",
-      "dependencies": ["@radix-ui/react-radio-group"],
       "files": [
         {
           "path": "registry/default/ui/radio-group.tsx",
@@ -289,7 +237,6 @@
     {
       "name": "scroll-area",
       "type": "registry:ui",
-      "dependencies": ["@radix-ui/react-scroll-area"],
       "files": [
         {
           "path": "registry/default/ui/scroll-area.tsx",
@@ -310,7 +257,6 @@
     {
       "name": "select",
       "type": "registry:ui",
-      "dependencies": ["@radix-ui/react-select"],
       "files": [
         {
           "path": "registry/default/ui/select.tsx",
@@ -321,8 +267,6 @@
     {
       "name": "slider",
       "type": "registry:ui",
-      "dependencies": ["@radix-ui/react-slider"],
-      "registryDependencies": ["https://originui.com/r/tooltip.json"],
       "files": [
         {
           "path": "registry/default/ui/slider.tsx",
@@ -333,7 +277,6 @@
     {
       "name": "sonner",
       "type": "registry:ui",
-      "dependencies": ["sonner", "next-themes"],
       "files": [
         {
           "path": "registry/default/ui/sonner.tsx",
@@ -354,7 +297,6 @@
     {
       "name": "switch",
       "type": "registry:ui",
-      "dependencies": ["@radix-ui/react-switch"],
       "files": [
         {
           "path": "registry/default/ui/switch.tsx",
@@ -375,7 +317,6 @@
     {
       "name": "tabs",
       "type": "registry:ui",
-      "dependencies": ["@radix-ui/react-tabs"],
       "files": [
         {
           "path": "registry/default/ui/tabs.tsx",
@@ -396,7 +337,6 @@
     {
       "name": "timeline",
       "type": "registry:ui",
-      "dependencies": ["@radix-ui/react-slot"],
       "files": [
         {
           "path": "registry/default/ui/timeline.tsx",
@@ -407,18 +347,9 @@
     {
       "name": "toast",
       "type": "registry:ui",
-      "dependencies": ["@radix-ui/react-toast"],
       "files": [
         {
           "path": "registry/default/ui/toast.tsx",
-          "type": "registry:ui"
-        },
-        {
-          "path": "registry/default/hooks/use-toast.ts",
-          "type": "registry:hook"
-        },
-        {
-          "path": "registry/default/ui/toaster.tsx",
           "type": "registry:ui"
         }
       ]
@@ -426,7 +357,6 @@
     {
       "name": "toggle",
       "type": "registry:ui",
-      "dependencies": ["@radix-ui/react-toggle"],
       "files": [
         {
           "path": "registry/default/ui/toggle.tsx",
@@ -437,8 +367,6 @@
     {
       "name": "toggle-group",
       "type": "registry:ui",
-      "dependencies": ["@radix-ui/react-toggle-group"],
-      "registryDependencies": ["toggle"],
       "files": [
         {
           "path": "registry/default/ui/toggle-group.tsx",
@@ -449,7 +377,6 @@
     {
       "name": "tooltip",
       "type": "registry:ui",
-      "dependencies": ["@radix-ui/react-tooltip"],
       "files": [
         {
           "path": "registry/default/ui/tooltip.tsx",
@@ -510,7 +437,6 @@
     {
       "name": "utils",
       "type": "registry:lib",
-      "dependencies": ["clsx", "tailwind-merge"],
       "files": [
         {
           "path": "registry/default/lib/utils.ts",
@@ -521,10 +447,6 @@
     {
       "name": "comp-01",
       "type": "registry:component",
-      "registryDependencies": [
-        "https://originui.com/r/input.json",
-        "https://originui.com/r/label.json"
-      ],
       "files": [
         {
           "path": "registry/default/components/comp-01.tsx",
@@ -538,10 +460,6 @@
     {
       "name": "comp-02",
       "type": "registry:component",
-      "registryDependencies": [
-        "https://originui.com/r/input.json",
-        "https://originui.com/r/label.json"
-      ],
       "files": [
         {
           "path": "registry/default/components/comp-02.tsx",
@@ -555,10 +473,6 @@
     {
       "name": "comp-03",
       "type": "registry:component",
-      "registryDependencies": [
-        "https://originui.com/r/input.json",
-        "https://originui.com/r/label.json"
-      ],
       "files": [
         {
           "path": "registry/default/components/comp-03.tsx",
@@ -572,10 +486,6 @@
     {
       "name": "comp-04",
       "type": "registry:component",
-      "registryDependencies": [
-        "https://originui.com/r/input.json",
-        "https://originui.com/r/label.json"
-      ],
       "files": [
         {
           "path": "registry/default/components/comp-04.tsx",
@@ -589,10 +499,6 @@
     {
       "name": "comp-05",
       "type": "registry:component",
-      "registryDependencies": [
-        "https://originui.com/r/input.json",
-        "https://originui.com/r/label.json"
-      ],
       "files": [
         {
           "path": "registry/default/components/comp-05.tsx",
@@ -606,10 +512,6 @@
     {
       "name": "comp-06",
       "type": "registry:component",
-      "registryDependencies": [
-        "https://originui.com/r/input.json",
-        "https://originui.com/r/label.json"
-      ],
       "files": [
         {
           "path": "registry/default/components/comp-06.tsx",
@@ -623,10 +525,6 @@
     {
       "name": "comp-07",
       "type": "registry:component",
-      "registryDependencies": [
-        "https://originui.com/r/input.json",
-        "https://originui.com/r/label.json"
-      ],
       "files": [
         {
           "path": "registry/default/components/comp-07.tsx",
@@ -640,10 +538,6 @@
     {
       "name": "comp-08",
       "type": "registry:component",
-      "registryDependencies": [
-        "https://originui.com/r/input.json",
-        "https://originui.com/r/label.json"
-      ],
       "files": [
         {
           "path": "registry/default/components/comp-08.tsx",
@@ -657,10 +551,6 @@
     {
       "name": "comp-09",
       "type": "registry:component",
-      "registryDependencies": [
-        "https://originui.com/r/input.json",
-        "https://originui.com/r/label.json"
-      ],
       "files": [
         {
           "path": "registry/default/components/comp-09.tsx",
@@ -674,10 +564,6 @@
     {
       "name": "comp-10",
       "type": "registry:component",
-      "registryDependencies": [
-        "https://originui.com/r/input.json",
-        "https://originui.com/r/label.json"
-      ],
       "files": [
         {
           "path": "registry/default/components/comp-10.tsx",
@@ -691,10 +577,6 @@
     {
       "name": "comp-11",
       "type": "registry:component",
-      "registryDependencies": [
-        "https://originui.com/r/input.json",
-        "https://originui.com/r/label.json"
-      ],
       "files": [
         {
           "path": "registry/default/components/comp-11.tsx",
@@ -708,10 +590,6 @@
     {
       "name": "comp-12",
       "type": "registry:component",
-      "registryDependencies": [
-        "https://originui.com/r/input.json",
-        "https://originui.com/r/label.json"
-      ],
       "files": [
         {
           "path": "registry/default/components/comp-12.tsx",
@@ -725,10 +603,6 @@
     {
       "name": "comp-13",
       "type": "registry:component",
-      "registryDependencies": [
-        "https://originui.com/r/input.json",
-        "https://originui.com/r/label.json"
-      ],
       "files": [
         {
           "path": "registry/default/components/comp-13.tsx",
@@ -742,10 +616,6 @@
     {
       "name": "comp-14",
       "type": "registry:component",
-      "registryDependencies": [
-        "https://originui.com/r/input.json",
-        "https://originui.com/r/label.json"
-      ],
       "files": [
         {
           "path": "registry/default/components/comp-14.tsx",
@@ -759,10 +629,6 @@
     {
       "name": "comp-15",
       "type": "registry:component",
-      "registryDependencies": [
-        "https://originui.com/r/input.json",
-        "https://originui.com/r/label.json"
-      ],
       "files": [
         {
           "path": "registry/default/components/comp-15.tsx",
@@ -776,10 +642,6 @@
     {
       "name": "comp-16",
       "type": "registry:component",
-      "registryDependencies": [
-        "https://originui.com/r/input.json",
-        "https://originui.com/r/label.json"
-      ],
       "files": [
         {
           "path": "registry/default/components/comp-16.tsx",
@@ -793,11 +655,6 @@
     {
       "name": "comp-17",
       "type": "registry:component",
-      "registryDependencies": [
-        "https://originui.com/r/input.json",
-        "https://originui.com/r/label.json",
-        "https://originui.com/r/select-native.json"
-      ],
       "files": [
         {
           "path": "registry/default/components/comp-17.tsx",
@@ -811,11 +668,6 @@
     {
       "name": "comp-18",
       "type": "registry:component",
-      "registryDependencies": [
-        "https://originui.com/r/input.json",
-        "https://originui.com/r/label.json",
-        "https://originui.com/r/select-native.json"
-      ],
       "files": [
         {
           "path": "registry/default/components/comp-18.tsx",
@@ -829,10 +681,6 @@
     {
       "name": "comp-19",
       "type": "registry:component",
-      "registryDependencies": [
-        "https://originui.com/r/input.json",
-        "https://originui.com/r/label.json"
-      ],
       "files": [
         {
           "path": "registry/default/components/comp-19.tsx",
@@ -846,10 +694,6 @@
     {
       "name": "comp-20",
       "type": "registry:component",
-      "registryDependencies": [
-        "https://originui.com/r/input.json",
-        "https://originui.com/r/label.json"
-      ],
       "files": [
         {
           "path": "registry/default/components/comp-20.tsx",
@@ -863,10 +707,6 @@
     {
       "name": "comp-21",
       "type": "registry:component",
-      "registryDependencies": [
-        "https://originui.com/r/input.json",
-        "https://originui.com/r/label.json"
-      ],
       "files": [
         {
           "path": "registry/default/components/comp-21.tsx",
@@ -880,10 +720,6 @@
     {
       "name": "comp-22",
       "type": "registry:component",
-      "registryDependencies": [
-        "https://originui.com/r/input.json",
-        "https://originui.com/r/label.json"
-      ],
       "files": [
         {
           "path": "registry/default/components/comp-22.tsx",
@@ -897,10 +733,6 @@
     {
       "name": "comp-23",
       "type": "registry:component",
-      "registryDependencies": [
-        "https://originui.com/r/input.json",
-        "https://originui.com/r/label.json"
-      ],
       "files": [
         {
           "path": "registry/default/components/comp-23.tsx",
@@ -914,10 +746,6 @@
     {
       "name": "comp-24",
       "type": "registry:component",
-      "registryDependencies": [
-        "https://originui.com/r/input.json",
-        "https://originui.com/r/label.json"
-      ],
       "files": [
         {
           "path": "registry/default/components/comp-24.tsx",
@@ -931,10 +759,6 @@
     {
       "name": "comp-25",
       "type": "registry:component",
-      "registryDependencies": [
-        "https://originui.com/r/input.json",
-        "https://originui.com/r/label.json"
-      ],
       "files": [
         {
           "path": "registry/default/components/comp-25.tsx",
@@ -948,10 +772,6 @@
     {
       "name": "comp-26",
       "type": "registry:component",
-      "registryDependencies": [
-        "https://originui.com/r/input.json",
-        "https://originui.com/r/label.json"
-      ],
       "files": [
         {
           "path": "registry/default/components/comp-26.tsx",
@@ -965,10 +785,6 @@
     {
       "name": "comp-27",
       "type": "registry:component",
-      "registryDependencies": [
-        "https://originui.com/r/input.json",
-        "https://originui.com/r/label.json"
-      ],
       "files": [
         {
           "path": "registry/default/components/comp-27.tsx",
@@ -982,7 +798,6 @@
     {
       "name": "comp-28",
       "type": "registry:component",
-      "dependencies": ["react-aria-components"],
       "files": [
         {
           "path": "registry/default/components/comp-28.tsx",
@@ -996,7 +811,6 @@
     {
       "name": "comp-29",
       "type": "registry:component",
-      "dependencies": ["react-aria-components"],
       "files": [
         {
           "path": "registry/default/components/comp-29.tsx",
@@ -1010,10 +824,6 @@
     {
       "name": "comp-30",
       "type": "registry:component",
-      "registryDependencies": [
-        "https://originui.com/r/input.json",
-        "https://originui.com/r/label.json"
-      ],
       "files": [
         {
           "path": "registry/default/components/comp-30.tsx",
@@ -1027,7 +837,6 @@
     {
       "name": "comp-31",
       "type": "registry:component",
-      "registryDependencies": ["https://originui.com/r/input.json"],
       "files": [
         {
           "path": "registry/default/components/comp-31.tsx",
@@ -1041,7 +850,6 @@
     {
       "name": "comp-32",
       "type": "registry:component",
-      "registryDependencies": ["https://originui.com/r/input.json"],
       "files": [
         {
           "path": "registry/default/components/comp-32.tsx",
@@ -1068,18 +876,10 @@
     {
       "name": "comp-34",
       "type": "registry:component",
-      "registryDependencies": [
-        "https://originui.com/r/input.json",
-        "https://originui.com/r/label.json"
-      ],
       "files": [
         {
           "path": "registry/default/components/comp-34.tsx",
           "type": "registry:component"
-        },
-        {
-          "path": "registry/default/hooks/use-character-limit.ts",
-          "type": "registry:hook"
         }
       ],
       "meta": {
@@ -1089,18 +889,10 @@
     {
       "name": "comp-35",
       "type": "registry:component",
-      "registryDependencies": [
-        "https://originui.com/r/input.json",
-        "https://originui.com/r/label.json"
-      ],
       "files": [
         {
           "path": "registry/default/components/comp-35.tsx",
           "type": "registry:component"
-        },
-        {
-          "path": "registry/default/hooks/use-character-limit.ts",
-          "type": "registry:hook"
         }
       ],
       "meta": {
@@ -1110,8 +902,6 @@
     {
       "name": "comp-36",
       "type": "registry:component",
-      "registryDependencies": ["https://originui.com/r/datefield-rac.json"],
-      "dependencies": ["react-aria-components"],
       "files": [
         {
           "path": "registry/default/components/comp-36.tsx",
@@ -1125,7 +915,6 @@
     {
       "name": "comp-37",
       "type": "registry:component",
-      "registryDependencies": ["https://originui.com/r/datefield-rac.json"],
       "files": [
         {
           "path": "registry/default/components/comp-37.tsx",
@@ -1139,7 +928,6 @@
     {
       "name": "comp-38",
       "type": "registry:component",
-      "registryDependencies": ["https://originui.com/r/datefield-rac.json"],
       "files": [
         {
           "path": "registry/default/components/comp-38.tsx",
@@ -1153,7 +941,6 @@
     {
       "name": "comp-39",
       "type": "registry:component",
-      "registryDependencies": ["https://originui.com/r/datefield-rac.json"],
       "files": [
         {
           "path": "registry/default/components/comp-39.tsx",
@@ -1167,7 +954,6 @@
     {
       "name": "comp-40",
       "type": "registry:component",
-      "registryDependencies": ["https://originui.com/r/datefield-rac.json"],
       "files": [
         {
           "path": "registry/default/components/comp-40.tsx",
@@ -1181,11 +967,6 @@
     {
       "name": "comp-41",
       "type": "registry:component",
-      "registryDependencies": [
-        "https://originui.com/r/calendar-rac.json",
-        "https://originui.com/r/datefield-rac.json"
-      ],
-      "dependencies": ["react-aria-components"],
       "files": [
         {
           "path": "registry/default/components/comp-41.tsx",
@@ -1199,11 +980,6 @@
     {
       "name": "comp-42",
       "type": "registry:component",
-      "registryDependencies": [
-        "https://originui.com/r/calendar-rac.json",
-        "https://originui.com/r/datefield-rac.json"
-      ],
-      "dependencies": ["react-aria-components"],
       "files": [
         {
           "path": "registry/default/components/comp-42.tsx",
@@ -1217,11 +993,6 @@
     {
       "name": "comp-43",
       "type": "registry:component",
-      "registryDependencies": [
-        "https://originui.com/r/calendar-rac.json",
-        "https://originui.com/r/datefield-rac.json"
-      ],
-      "dependencies": ["react-aria-components", "react-aria", "@internationalized/date"],
       "files": [
         {
           "path": "registry/default/components/comp-43.tsx",
@@ -1235,8 +1006,6 @@
     {
       "name": "comp-44",
       "type": "registry:component",
-      "registryDependencies": ["https://originui.com/r/label.json"],
-      "dependencies": ["input-otp"],
       "files": [
         {
           "path": "registry/default/components/comp-44.tsx",
@@ -1250,8 +1019,6 @@
     {
       "name": "comp-45",
       "type": "registry:component",
-      "registryDependencies": ["https://originui.com/r/label.json"],
-      "dependencies": ["input-otp"],
       "files": [
         {
           "path": "registry/default/components/comp-45.tsx",
@@ -1265,11 +1032,6 @@
     {
       "name": "comp-46",
       "type": "registry:component",
-      "registryDependencies": [
-        "https://originui.com/r/input.json",
-        "https://originui.com/r/label.json"
-      ],
-      "dependencies": ["react-phone-number-input"],
       "files": [
         {
           "path": "registry/default/components/comp-46.tsx",
@@ -1283,12 +1045,6 @@
     {
       "name": "comp-47",
       "type": "registry:component",
-      "registryDependencies": [
-        "https://originui.com/r/input.json",
-        "https://originui.com/r/label.json"
-      ],
-      "dependencies": ["react-payment-inputs"],
-      "devDependencies": ["@types/react-payment-inputs"],
       "files": [
         {
           "path": "registry/default/components/comp-47.tsx",
@@ -1302,12 +1058,6 @@
     {
       "name": "comp-48",
       "type": "registry:component",
-      "registryDependencies": [
-        "https://originui.com/r/input.json",
-        "https://originui.com/r/label.json"
-      ],
-      "dependencies": ["react-payment-inputs"],
-      "devDependencies": ["@types/react-payment-inputs"],
       "files": [
         {
           "path": "registry/default/components/comp-48.tsx",
@@ -1321,12 +1071,6 @@
     {
       "name": "comp-49",
       "type": "registry:component",
-      "registryDependencies": [
-        "https://originui.com/r/input.json",
-        "https://originui.com/r/label.json"
-      ],
-      "dependencies": ["react-payment-inputs"],
-      "devDependencies": ["@types/react-payment-inputs"],
       "files": [
         {
           "path": "registry/default/components/comp-49.tsx",
@@ -1340,12 +1084,6 @@
     {
       "name": "comp-50",
       "type": "registry:component",
-      "registryDependencies": [
-        "https://originui.com/r/input.json",
-        "https://originui.com/r/label.json"
-      ],
-      "dependencies": ["react-payment-inputs"],
-      "devDependencies": ["@types/react-payment-inputs"],
       "files": [
         {
           "path": "registry/default/components/comp-50.tsx",
@@ -1359,10 +1097,6 @@
     {
       "name": "comp-51",
       "type": "registry:component",
-      "registryDependencies": [
-        "https://originui.com/r/input.json",
-        "https://originui.com/r/label.json"
-      ],
       "files": [
         {
           "path": "registry/default/components/comp-51.tsx",
@@ -1376,10 +1110,6 @@
     {
       "name": "comp-52",
       "type": "registry:component",
-      "registryDependencies": [
-        "https://originui.com/r/input.json",
-        "https://originui.com/r/label.json"
-      ],
       "files": [
         {
           "path": "registry/default/components/comp-52.tsx",
@@ -1393,11 +1123,6 @@
     {
       "name": "comp-53",
       "type": "registry:component",
-      "registryDependencies": [
-        "https://originui.com/r/input.json",
-        "https://originui.com/r/label.json",
-        "https://originui.com/r/tooltip.json"
-      ],
       "files": [
         {
           "path": "registry/default/components/comp-53.tsx",
@@ -1411,11 +1136,6 @@
     {
       "name": "comp-54",
       "type": "registry:component",
-      "registryDependencies": [
-        "https://originui.com/r/input.json",
-        "https://originui.com/r/label.json"
-      ],
-      "dependencies": ["use-mask-input"],
       "files": [
         {
           "path": "registry/default/components/comp-54.tsx",
@@ -1429,11 +1149,6 @@
     {
       "name": "comp-55",
       "type": "registry:component",
-      "registryDependencies": [
-        "https://originui.com/r/input.json",
-        "https://originui.com/r/label.json"
-      ],
-      "dependencies": ["use-mask-input"],
       "files": [
         {
           "path": "registry/default/components/comp-55.tsx",
@@ -1447,8 +1162,6 @@
     {
       "name": "comp-56",
       "type": "registry:component",
-      "registryDependencies": ["https://originui.com/r/label.json"],
-      "dependencies": ["emblor"],
       "files": [
         {
           "path": "registry/default/components/comp-56.tsx",
@@ -1462,8 +1175,6 @@
     {
       "name": "comp-57",
       "type": "registry:component",
-      "registryDependencies": ["https://originui.com/r/label.json"],
-      "dependencies": ["emblor"],
       "files": [
         {
           "path": "registry/default/components/comp-57.tsx",
@@ -1477,8 +1188,6 @@
     {
       "name": "comp-58",
       "type": "registry:component",
-      "registryDependencies": ["https://originui.com/r/label.json"],
-      "dependencies": ["input-otp"],
       "files": [
         {
           "path": "registry/default/components/comp-58.tsx",
@@ -1492,10 +1201,6 @@
     {
       "name": "comp-59",
       "type": "registry:component",
-      "registryDependencies": [
-        "https://originui.com/r/label.json",
-        "https://originui.com/r/textarea.json"
-      ],
       "files": [
         {
           "path": "registry/default/components/comp-59.tsx",
@@ -1509,10 +1214,6 @@
     {
       "name": "comp-60",
       "type": "registry:component",
-      "registryDependencies": [
-        "https://originui.com/r/label.json",
-        "https://originui.com/r/textarea.json"
-      ],
       "files": [
         {
           "path": "registry/default/components/comp-60.tsx",
@@ -1526,10 +1227,6 @@
     {
       "name": "comp-61",
       "type": "registry:component",
-      "registryDependencies": [
-        "https://originui.com/r/label.json",
-        "https://originui.com/r/textarea.json"
-      ],
       "files": [
         {
           "path": "registry/default/components/comp-61.tsx",
@@ -1543,10 +1240,6 @@
     {
       "name": "comp-62",
       "type": "registry:component",
-      "registryDependencies": [
-        "https://originui.com/r/label.json",
-        "https://originui.com/r/textarea.json"
-      ],
       "files": [
         {
           "path": "registry/default/components/comp-63.tsx",
@@ -1560,10 +1253,6 @@
     {
       "name": "comp-63",
       "type": "registry:component",
-      "registryDependencies": [
-        "https://originui.com/r/label.json",
-        "https://originui.com/r/textarea.json"
-      ],
       "files": [
         {
           "path": "registry/default/components/comp-63.tsx",
@@ -1577,10 +1266,6 @@
     {
       "name": "comp-64",
       "type": "registry:component",
-      "registryDependencies": [
-        "https://originui.com/r/label.json",
-        "https://originui.com/r/textarea.json"
-      ],
       "files": [
         {
           "path": "registry/default/components/comp-64.tsx",
@@ -1594,10 +1279,6 @@
     {
       "name": "comp-65",
       "type": "registry:component",
-      "registryDependencies": [
-        "https://originui.com/r/label.json",
-        "https://originui.com/r/textarea.json"
-      ],
       "files": [
         {
           "path": "registry/default/components/comp-65.tsx",
@@ -1611,10 +1292,6 @@
     {
       "name": "comp-66",
       "type": "registry:component",
-      "registryDependencies": [
-        "https://originui.com/r/label.json",
-        "https://originui.com/r/textarea.json"
-      ],
       "files": [
         {
           "path": "registry/default/components/comp-66.tsx",
@@ -1628,10 +1305,6 @@
     {
       "name": "comp-67",
       "type": "registry:component",
-      "registryDependencies": [
-        "https://originui.com/r/label.json",
-        "https://originui.com/r/textarea.json"
-      ],
       "files": [
         {
           "path": "registry/default/components/comp-67.tsx",
@@ -1645,11 +1318,6 @@
     {
       "name": "comp-68",
       "type": "registry:component",
-      "registryDependencies": [
-        "https://originui.com/r/button.json",
-        "https://originui.com/r/label.json",
-        "https://originui.com/r/textarea.json"
-      ],
       "files": [
         {
           "path": "registry/default/components/comp-68.tsx",
@@ -1663,11 +1331,6 @@
     {
       "name": "comp-69",
       "type": "registry:component",
-      "registryDependencies": [
-        "https://originui.com/r/button.json",
-        "https://originui.com/r/label.json",
-        "https://originui.com/r/textarea.json"
-      ],
       "files": [
         {
           "path": "registry/default/components/comp-69.tsx",
@@ -1681,11 +1344,6 @@
     {
       "name": "comp-70",
       "type": "registry:component",
-      "registryDependencies": [
-        "https://originui.com/r/button.json",
-        "https://originui.com/r/label.json",
-        "https://originui.com/r/textarea.json"
-      ],
       "files": [
         {
           "path": "registry/default/components/comp-70.tsx",
@@ -1699,10 +1357,6 @@
     {
       "name": "comp-71",
       "type": "registry:component",
-      "registryDependencies": [
-        "https://originui.com/r/label.json",
-        "https://originui.com/r/textarea.json"
-      ],
       "files": [
         {
           "path": "registry/default/components/comp-71.tsx",
@@ -1716,7 +1370,6 @@
     {
       "name": "comp-72",
       "type": "registry:component",
-      "registryDependencies": ["https://originui.com/r/textarea.json"],
       "files": [
         {
           "path": "registry/default/components/comp-72.tsx",
@@ -1743,18 +1396,10 @@
     {
       "name": "comp-74",
       "type": "registry:component",
-      "registryDependencies": [
-        "https://originui.com/r/label.json",
-        "https://originui.com/r/textarea.json"
-      ],
       "files": [
         {
           "path": "registry/default/components/comp-74.tsx",
           "type": "registry:component"
-        },
-        {
-          "path": "registry/default/hooks/use-character-limit.ts",
-          "type": "registry:hook"
         }
       ],
       "meta": {
@@ -1764,10 +1409,6 @@
     {
       "name": "comp-75",
       "type": "registry:component",
-      "registryDependencies": [
-        "https://originui.com/r/label.json",
-        "https://originui.com/r/textarea.json"
-      ],
       "files": [
         {
           "path": "registry/default/components/comp-75.tsx",
@@ -1781,10 +1422,6 @@
     {
       "name": "comp-76",
       "type": "registry:component",
-      "registryDependencies": [
-        "https://originui.com/r/label.json",
-        "https://originui.com/r/textarea.json"
-      ],
       "files": [
         {
           "path": "registry/default/components/comp-76.tsx",
@@ -1798,10 +1435,6 @@
     {
       "name": "comp-77",
       "type": "registry:component",
-      "registryDependencies": [
-        "https://originui.com/r/label.json",
-        "https://originui.com/r/textarea.json"
-      ],
       "files": [
         {
           "path": "registry/default/components/comp-77.tsx",
@@ -1815,7 +1448,6 @@
     {
       "name": "comp-78",
       "type": "registry:component",
-      "registryDependencies": ["https://originui.com/r/button.json"],
       "files": [
         {
           "path": "registry/default/components/comp-78.tsx",
@@ -1830,7 +1462,6 @@
     {
       "name": "comp-79",
       "type": "registry:component",
-      "registryDependencies": ["https://originui.com/r/button.json"],
       "files": [
         {
           "path": "registry/default/components/comp-79.tsx",
@@ -1845,7 +1476,6 @@
     {
       "name": "comp-80",
       "type": "registry:component",
-      "registryDependencies": ["https://originui.com/r/button.json"],
       "files": [
         {
           "path": "registry/default/components/comp-80.tsx",
@@ -1860,7 +1490,6 @@
     {
       "name": "comp-81",
       "type": "registry:component",
-      "registryDependencies": ["https://originui.com/r/button.json"],
       "files": [
         {
           "path": "registry/default/components/comp-81.tsx",
@@ -1875,7 +1504,6 @@
     {
       "name": "comp-82",
       "type": "registry:component",
-      "registryDependencies": ["https://originui.com/r/button.json"],
       "files": [
         {
           "path": "registry/default/components/comp-82.tsx",
@@ -1890,7 +1518,6 @@
     {
       "name": "comp-83",
       "type": "registry:component",
-      "registryDependencies": ["https://originui.com/r/button.json"],
       "files": [
         {
           "path": "registry/default/components/comp-83.tsx",
@@ -1905,7 +1532,6 @@
     {
       "name": "comp-84",
       "type": "registry:component",
-      "registryDependencies": ["https://originui.com/r/button.json"],
       "files": [
         {
           "path": "registry/default/components/comp-84.tsx",
@@ -1920,7 +1546,6 @@
     {
       "name": "comp-85",
       "type": "registry:component",
-      "registryDependencies": ["https://originui.com/r/button.json"],
       "files": [
         {
           "path": "registry/default/components/comp-85.tsx",
@@ -1935,7 +1560,6 @@
     {
       "name": "comp-86",
       "type": "registry:component",
-      "registryDependencies": ["https://originui.com/r/button.json"],
       "files": [
         {
           "path": "registry/default/components/comp-86.tsx",
@@ -1950,7 +1574,6 @@
     {
       "name": "comp-87",
       "type": "registry:component",
-      "registryDependencies": ["https://originui.com/r/button.json"],
       "files": [
         {
           "path": "registry/default/components/comp-87.tsx",
@@ -1965,7 +1588,6 @@
     {
       "name": "comp-88",
       "type": "registry:component",
-      "registryDependencies": ["https://originui.com/r/button.json"],
       "files": [
         {
           "path": "registry/default/components/comp-88.tsx",
@@ -1980,7 +1602,6 @@
     {
       "name": "comp-89",
       "type": "registry:component",
-      "registryDependencies": ["https://originui.com/r/button.json"],
       "files": [
         {
           "path": "registry/default/components/comp-89.tsx",
@@ -1995,7 +1616,6 @@
     {
       "name": "comp-90",
       "type": "registry:component",
-      "registryDependencies": ["https://originui.com/r/button.json"],
       "files": [
         {
           "path": "registry/default/components/comp-90.tsx",
@@ -2010,7 +1630,6 @@
     {
       "name": "comp-91",
       "type": "registry:component",
-      "registryDependencies": ["https://originui.com/r/button.json"],
       "files": [
         {
           "path": "registry/default/components/comp-91.tsx",
@@ -2025,7 +1644,6 @@
     {
       "name": "comp-92",
       "type": "registry:component",
-      "registryDependencies": ["https://originui.com/r/button.json"],
       "files": [
         {
           "path": "registry/default/components/comp-92.tsx",
@@ -2040,7 +1658,6 @@
     {
       "name": "comp-93",
       "type": "registry:component",
-      "registryDependencies": ["https://originui.com/r/button.json"],
       "files": [
         {
           "path": "registry/default/components/comp-93.tsx",
@@ -2055,7 +1672,6 @@
     {
       "name": "comp-94",
       "type": "registry:component",
-      "registryDependencies": ["https://originui.com/r/button.json"],
       "files": [
         {
           "path": "registry/default/components/comp-94.tsx",
@@ -2070,7 +1686,6 @@
     {
       "name": "comp-95",
       "type": "registry:component",
-      "registryDependencies": ["https://originui.com/r/button.json"],
       "files": [
         {
           "path": "registry/default/components/comp-95.tsx",
@@ -2085,7 +1700,6 @@
     {
       "name": "comp-96",
       "type": "registry:component",
-      "registryDependencies": ["https://originui.com/r/button.json"],
       "files": [
         {
           "path": "registry/default/components/comp-96.tsx",
@@ -2100,7 +1714,6 @@
     {
       "name": "comp-97",
       "type": "registry:component",
-      "registryDependencies": ["https://originui.com/r/button.json"],
       "files": [
         {
           "path": "registry/default/components/comp-97.tsx",
@@ -2115,7 +1728,6 @@
     {
       "name": "comp-98",
       "type": "registry:component",
-      "registryDependencies": ["https://originui.com/r/button.json"],
       "files": [
         {
           "path": "registry/default/components/comp-98.tsx",
@@ -2130,10 +1742,6 @@
     {
       "name": "comp-99",
       "type": "registry:component",
-      "registryDependencies": [
-        "https://originui.com/r/button.json",
-        "https://originui.com/r/tooltip.json"
-      ],
       "files": [
         {
           "path": "registry/default/components/comp-99.tsx",
@@ -2148,7 +1756,6 @@
     {
       "name": "comp-100",
       "type": "registry:component",
-      "registryDependencies": ["https://originui.com/r/button.json"],
       "files": [
         {
           "path": "registry/default/components/comp-100.tsx",
@@ -2163,10 +1770,6 @@
     {
       "name": "comp-101",
       "type": "registry:component",
-      "registryDependencies": [
-        "https://originui.com/r/toggle.json",
-        "https://originui.com/r/tooltip.json"
-      ],
       "files": [
         {
           "path": "registry/default/components/comp-101.tsx",
@@ -2181,7 +1784,6 @@
     {
       "name": "comp-102",
       "type": "registry:component",
-      "registryDependencies": ["https://originui.com/r/button.json"],
       "files": [
         {
           "path": "registry/default/components/comp-102.tsx",
@@ -2196,7 +1798,6 @@
     {
       "name": "comp-103",
       "type": "registry:component",
-      "registryDependencies": ["https://originui.com/r/button.json"],
       "files": [
         {
           "path": "registry/default/components/comp-103.tsx",
@@ -2211,7 +1812,6 @@
     {
       "name": "comp-104",
       "type": "registry:component",
-      "registryDependencies": ["https://originui.com/r/button.json"],
       "files": [
         {
           "path": "registry/default/components/comp-104.tsx",
@@ -2226,10 +1826,6 @@
     {
       "name": "comp-105",
       "type": "registry:component",
-      "registryDependencies": [
-        "https://originui.com/r/button.json",
-        "https://originui.com/r/tooltip.json"
-      ],
       "files": [
         {
           "path": "registry/default/components/comp-105.tsx",
@@ -2244,7 +1840,6 @@
     {
       "name": "comp-106",
       "type": "registry:component",
-      "registryDependencies": ["https://originui.com/r/button.json"],
       "files": [
         {
           "path": "registry/default/components/comp-106.tsx",
@@ -2259,7 +1854,6 @@
     {
       "name": "comp-107",
       "type": "registry:component",
-      "registryDependencies": ["https://originui.com/r/toggle-group.json"],
       "files": [
         {
           "path": "registry/default/components/comp-107.tsx",
@@ -2274,7 +1868,6 @@
     {
       "name": "comp-108",
       "type": "registry:component",
-      "registryDependencies": ["https://originui.com/r/button.json"],
       "files": [
         {
           "path": "registry/default/components/comp-108.tsx",
@@ -2289,7 +1882,6 @@
     {
       "name": "comp-109",
       "type": "registry:component",
-      "registryDependencies": ["https://originui.com/r/toggle-group.json"],
       "files": [
         {
           "path": "registry/default/components/comp-109.tsx",
@@ -2304,7 +1896,6 @@
     {
       "name": "comp-110",
       "type": "registry:component",
-      "registryDependencies": ["https://originui.com/r/toggle-group.json"],
       "files": [
         {
           "path": "registry/default/components/comp-110.tsx",
@@ -2319,7 +1910,6 @@
     {
       "name": "comp-111",
       "type": "registry:component",
-      "registryDependencies": ["https://originui.com/r/button.json"],
       "files": [
         {
           "path": "registry/default/components/comp-111.tsx",
@@ -2334,7 +1924,6 @@
     {
       "name": "comp-112",
       "type": "registry:component",
-      "registryDependencies": ["https://originui.com/r/button.json"],
       "files": [
         {
           "path": "registry/default/components/comp-112.tsx",
@@ -2349,7 +1938,6 @@
     {
       "name": "comp-113",
       "type": "registry:component",
-      "registryDependencies": ["https://originui.com/r/button.json"],
       "files": [
         {
           "path": "registry/default/components/comp-113.tsx",
@@ -2364,7 +1952,6 @@
     {
       "name": "comp-114",
       "type": "registry:component",
-      "registryDependencies": ["https://originui.com/r/button.json"],
       "files": [
         {
           "path": "registry/default/components/comp-114.tsx",
@@ -2379,7 +1966,6 @@
     {
       "name": "comp-115",
       "type": "registry:component",
-      "registryDependencies": ["https://originui.com/r/button.json"],
       "files": [
         {
           "path": "registry/default/components/comp-115.tsx",
@@ -2394,7 +1980,6 @@
     {
       "name": "comp-116",
       "type": "registry:component",
-      "registryDependencies": ["https://originui.com/r/button.json"],
       "files": [
         {
           "path": "registry/default/components/comp-116.tsx",
@@ -2409,7 +1994,6 @@
     {
       "name": "comp-117",
       "type": "registry:component",
-      "registryDependencies": ["https://originui.com/r/button.json"],
       "files": [
         {
           "path": "registry/default/components/comp-117.tsx",
@@ -2424,7 +2008,6 @@
     {
       "name": "comp-118",
       "type": "registry:component",
-      "registryDependencies": ["https://originui.com/r/button.json"],
       "files": [
         {
           "path": "registry/default/components/comp-118.tsx",
@@ -2439,8 +2022,6 @@
     {
       "name": "comp-119",
       "type": "registry:component",
-      "registryDependencies": ["https://originui.com/r/button.json"],
-      "dependencies": ["@remixicon/react"],
       "files": [
         {
           "path": "registry/default/components/comp-119.tsx",
@@ -2455,8 +2036,6 @@
     {
       "name": "comp-120",
       "type": "registry:component",
-      "registryDependencies": ["https://originui.com/r/button.json"],
-      "dependencies": ["@remixicon/react"],
       "files": [
         {
           "path": "registry/default/components/comp-120.tsx",
@@ -2471,8 +2050,6 @@
     {
       "name": "comp-121",
       "type": "registry:component",
-      "registryDependencies": ["https://originui.com/r/button.json"],
-      "dependencies": ["@remixicon/react"],
       "files": [
         {
           "path": "registry/default/components/comp-121.tsx",
@@ -2487,8 +2064,6 @@
     {
       "name": "comp-122",
       "type": "registry:component",
-      "registryDependencies": ["https://originui.com/r/button.json"],
-      "dependencies": ["@remixicon/react"],
       "files": [
         {
           "path": "registry/default/components/comp-122.tsx",
@@ -2503,7 +2078,6 @@
     {
       "name": "comp-123",
       "type": "registry:component",
-      "registryDependencies": ["https://originui.com/r/button.json"],
       "files": [
         {
           "path": "registry/default/components/comp-123.tsx",
@@ -2518,7 +2092,6 @@
     {
       "name": "comp-124",
       "type": "registry:component",
-      "registryDependencies": ["https://originui.com/r/button.json"],
       "files": [
         {
           "path": "registry/default/components/comp-124.tsx",
@@ -2533,15 +2106,10 @@
     {
       "name": "comp-125",
       "type": "registry:component",
-      "registryDependencies": ["https://originui.com/r/button.json"],
       "files": [
         {
           "path": "registry/default/components/comp-125.tsx",
           "type": "registry:component"
-        },
-        {
-          "path": "registry/default/hooks/use-file-upload.ts",
-          "type": "registry:hook"
         }
       ],
       "meta": {
@@ -2552,15 +2120,10 @@
     {
       "name": "comp-126",
       "type": "registry:component",
-      "registryDependencies": ["https://originui.com/r/button.json"],
       "files": [
         {
           "path": "registry/default/components/comp-126.tsx",
           "type": "registry:component"
-        },
-        {
-          "path": "registry/default/hooks/use-file-upload.ts",
-          "type": "registry:hook"
         }
       ],
       "meta": {
@@ -2571,7 +2134,6 @@
     {
       "name": "comp-127",
       "type": "registry:component",
-      "registryDependencies": ["https://originui.com/r/button.json"],
       "files": [
         {
           "path": "registry/default/components/comp-127.tsx",
@@ -2586,7 +2148,6 @@
     {
       "name": "comp-128",
       "type": "registry:component",
-      "registryDependencies": ["https://originui.com/r/button.json"],
       "files": [
         {
           "path": "registry/default/components/comp-128.tsx",
@@ -2601,10 +2162,6 @@
     {
       "name": "comp-129",
       "type": "registry:component",
-      "registryDependencies": [
-        "https://originui.com/r/badge.json",
-        "https://originui.com/r/button.json"
-      ],
       "files": [
         {
           "path": "registry/default/components/comp-129.tsx",
@@ -2619,7 +2176,6 @@
     {
       "name": "comp-130",
       "type": "registry:component",
-      "registryDependencies": ["https://originui.com/r/toggle.json"],
       "files": [
         {
           "path": "registry/default/components/comp-130.tsx",
@@ -2634,10 +2190,6 @@
     {
       "name": "comp-131",
       "type": "registry:component",
-      "registryDependencies": [
-        "https://originui.com/r/button.json",
-        "https://originui.com/r/dropdown-menu.json"
-      ],
       "files": [
         {
           "path": "registry/default/components/comp-131.tsx",
@@ -2652,10 +2204,6 @@
     {
       "name": "comp-132",
       "type": "registry:component",
-      "registryDependencies": [
-        "https://originui.com/r/checkbox.json",
-        "https://originui.com/r/label.json"
-      ],
       "files": [
         {
           "path": "registry/default/components/comp-132.tsx",
@@ -2669,10 +2217,6 @@
     {
       "name": "comp-133",
       "type": "registry:component",
-      "registryDependencies": [
-        "https://originui.com/r/checkbox.json",
-        "https://originui.com/r/label.json"
-      ],
       "files": [
         {
           "path": "registry/default/components/comp-133.tsx",
@@ -2686,10 +2230,6 @@
     {
       "name": "comp-134",
       "type": "registry:component",
-      "registryDependencies": [
-        "https://originui.com/r/checkbox.json",
-        "https://originui.com/r/label.json"
-      ],
       "files": [
         {
           "path": "registry/default/components/comp-134.tsx",
@@ -2703,10 +2243,6 @@
     {
       "name": "comp-135",
       "type": "registry:component",
-      "registryDependencies": [
-        "https://originui.com/r/checkbox.json",
-        "https://originui.com/r/label.json"
-      ],
       "files": [
         {
           "path": "registry/default/components/comp-135.tsx",
@@ -2720,10 +2256,6 @@
     {
       "name": "comp-136",
       "type": "registry:component",
-      "registryDependencies": [
-        "https://originui.com/r/checkbox.json",
-        "https://originui.com/r/label.json"
-      ],
       "files": [
         {
           "path": "registry/default/components/comp-136.tsx",
@@ -2737,10 +2269,6 @@
     {
       "name": "comp-137",
       "type": "registry:component",
-      "registryDependencies": [
-        "https://originui.com/r/checkbox.json",
-        "https://originui.com/r/label.json"
-      ],
       "files": [
         {
           "path": "registry/default/components/comp-137.tsx",
@@ -2754,10 +2282,6 @@
     {
       "name": "comp-138",
       "type": "registry:component",
-      "registryDependencies": [
-        "https://originui.com/r/checkbox.json",
-        "https://originui.com/r/label.json"
-      ],
       "files": [
         {
           "path": "registry/default/components/comp-138.tsx",
@@ -2771,10 +2295,6 @@
     {
       "name": "comp-139",
       "type": "registry:component",
-      "registryDependencies": [
-        "https://originui.com/r/checkbox.json",
-        "https://originui.com/r/label.json"
-      ],
       "files": [
         {
           "path": "registry/default/components/comp-139.tsx",
@@ -2788,10 +2308,6 @@
     {
       "name": "comp-140",
       "type": "registry:component",
-      "registryDependencies": [
-        "https://originui.com/r/checkbox.json",
-        "https://originui.com/r/label.json"
-      ],
       "files": [
         {
           "path": "registry/default/components/comp-140.tsx",
@@ -2805,10 +2321,6 @@
     {
       "name": "comp-141",
       "type": "registry:component",
-      "registryDependencies": [
-        "https://originui.com/r/checkbox.json",
-        "https://originui.com/r/label.json"
-      ],
       "files": [
         {
           "path": "registry/default/components/comp-141.tsx",
@@ -2822,11 +2334,6 @@
     {
       "name": "comp-142",
       "type": "registry:component",
-      "registryDependencies": [
-        "https://originui.com/r/checkbox.json",
-        "https://originui.com/r/label.json",
-        "https://originui.com/r/input.json"
-      ],
       "files": [
         {
           "path": "registry/default/components/comp-142.tsx",
@@ -2840,10 +2347,6 @@
     {
       "name": "comp-143",
       "type": "registry:component",
-      "registryDependencies": [
-        "https://originui.com/r/checkbox.json",
-        "https://originui.com/r/label.json"
-      ],
       "files": [
         {
           "path": "registry/default/components/comp-143.tsx",
@@ -2857,10 +2360,6 @@
     {
       "name": "comp-144",
       "type": "registry:component",
-      "registryDependencies": [
-        "https://originui.com/r/checkbox.json",
-        "https://originui.com/r/label.json"
-      ],
       "files": [
         {
           "path": "registry/default/components/comp-144.tsx",
@@ -2874,10 +2373,6 @@
     {
       "name": "comp-145",
       "type": "registry:component",
-      "registryDependencies": [
-        "https://originui.com/r/checkbox.json",
-        "https://originui.com/r/label.json"
-      ],
       "files": [
         {
           "path": "registry/default/components/comp-145.tsx",
@@ -2891,10 +2386,6 @@
     {
       "name": "comp-146",
       "type": "registry:component",
-      "registryDependencies": [
-        "https://originui.com/r/checkbox.json",
-        "https://originui.com/r/label.json"
-      ],
       "files": [
         {
           "path": "registry/default/components/comp-146.tsx",
@@ -2908,10 +2399,6 @@
     {
       "name": "comp-147",
       "type": "registry:component",
-      "registryDependencies": [
-        "https://originui.com/r/checkbox.json",
-        "https://originui.com/r/label.json"
-      ],
       "files": [
         {
           "path": "registry/default/components/comp-147.tsx",
@@ -2925,11 +2412,6 @@
     {
       "name": "comp-148",
       "type": "registry:component",
-      "registryDependencies": [
-        "https://originui.com/r/checkbox.json",
-        "https://originui.com/r/checkbox-tree.json",
-        "https://originui.com/r/label.json"
-      ],
       "files": [
         {
           "path": "registry/default/components/comp-148.tsx",
@@ -2943,7 +2425,6 @@
     {
       "name": "comp-149",
       "type": "registry:component",
-      "registryDependencies": ["https://originui.com/r/checkbox.json"],
       "files": [
         {
           "path": "registry/default/components/comp-149.tsx",
@@ -2970,10 +2451,6 @@
     {
       "name": "comp-151",
       "type": "registry:component",
-      "registryDependencies": [
-        "https://originui.com/r/checkbox.json",
-        "https://originui.com/r/label.json"
-      ],
       "files": [
         {
           "path": "registry/default/components/comp-151.tsx",
@@ -2987,10 +2464,6 @@
     {
       "name": "comp-152",
       "type": "registry:component",
-      "registryDependencies": [
-        "https://originui.com/r/label.json",
-        "https://originui.com/r/radio-group.json"
-      ],
       "files": [
         {
           "path": "registry/default/components/comp-152.tsx",
@@ -3004,10 +2477,6 @@
     {
       "name": "comp-153",
       "type": "registry:component",
-      "registryDependencies": [
-        "https://originui.com/r/label.json",
-        "https://originui.com/r/radio-group.json"
-      ],
       "files": [
         {
           "path": "registry/default/components/comp-153.tsx",
@@ -3021,10 +2490,6 @@
     {
       "name": "comp-154",
       "type": "registry:component",
-      "registryDependencies": [
-        "https://originui.com/r/label.json",
-        "https://originui.com/r/radio-group.json"
-      ],
       "files": [
         {
           "path": "registry/default/components/comp-154.tsx",
@@ -3038,10 +2503,6 @@
     {
       "name": "comp-155",
       "type": "registry:component",
-      "registryDependencies": [
-        "https://originui.com/r/label.json",
-        "https://originui.com/r/radio-group.json"
-      ],
       "files": [
         {
           "path": "registry/default/components/comp-155.tsx",
@@ -3055,11 +2516,6 @@
     {
       "name": "comp-156",
       "type": "registry:component",
-      "registryDependencies": [
-        "https://originui.com/r/input.json",
-        "https://originui.com/r/label.json",
-        "https://originui.com/r/radio-group.json"
-      ],
       "files": [
         {
           "path": "registry/default/components/comp-156.tsx",
@@ -3073,11 +2529,6 @@
     {
       "name": "comp-157",
       "type": "registry:component",
-      "registryDependencies": [
-        "https://originui.com/r/label.json",
-        "https://originui.com/r/radio-group.json"
-      ],
-      "dependencies": ["@remixicon/react"],
       "files": [
         {
           "path": "registry/default/components/comp-157.tsx",
@@ -3091,7 +2542,6 @@
     {
       "name": "comp-158",
       "type": "registry:component",
-      "registryDependencies": ["https://originui.com/r/radio-group.json"],
       "files": [
         {
           "path": "registry/default/components/comp-158.tsx",
@@ -3105,10 +2555,6 @@
     {
       "name": "comp-159",
       "type": "registry:component",
-      "registryDependencies": [
-        "https://originui.com/r/label.json",
-        "https://originui.com/r/radio-group.json"
-      ],
       "files": [
         {
           "path": "registry/default/components/comp-159.tsx",
@@ -3122,10 +2568,6 @@
     {
       "name": "comp-160",
       "type": "registry:component",
-      "registryDependencies": [
-        "https://originui.com/r/label.json",
-        "https://originui.com/r/radio-group.json"
-      ],
       "files": [
         {
           "path": "registry/default/components/comp-160.tsx",
@@ -3139,10 +2581,6 @@
     {
       "name": "comp-161",
       "type": "registry:component",
-      "registryDependencies": [
-        "https://originui.com/r/radio-group.json",
-        "https://originui.com/r/label.json"
-      ],
       "files": [
         {
           "path": "registry/default/components/comp-161.tsx",
@@ -3156,10 +2594,6 @@
     {
       "name": "comp-162",
       "type": "registry:component",
-      "registryDependencies": [
-        "https://originui.com/r/radio-group.json",
-        "https://originui.com/r/label.json"
-      ],
       "files": [
         {
           "path": "registry/default/components/comp-162.tsx",
@@ -3173,8 +2607,6 @@
     {
       "name": "comp-163",
       "type": "registry:component",
-      "registryDependencies": ["https://originui.com/r/radio-group.json"],
-      "dependencies": ["@remixicon/react"],
       "files": [
         {
           "path": "registry/default/components/comp-163.tsx",
@@ -3188,7 +2620,6 @@
     {
       "name": "comp-164",
       "type": "registry:component",
-      "registryDependencies": ["https://originui.com/r/radio-group.json"],
       "files": [
         {
           "path": "registry/default/components/comp-164.tsx",
@@ -3202,10 +2633,6 @@
     {
       "name": "comp-165",
       "type": "registry:component",
-      "registryDependencies": [
-        "https://originui.com/r/radio-group.json",
-        "https://originui.com/r/label.json"
-      ],
       "files": [
         {
           "path": "registry/default/components/comp-165.tsx",
@@ -3219,11 +2646,6 @@
     {
       "name": "comp-166",
       "type": "registry:component",
-      "registryDependencies": [
-        "https://originui.com/r/radio-group.json",
-        "https://originui.com/r/label.json",
-        "https://originui.com/r/badge.json"
-      ],
       "files": [
         {
           "path": "registry/default/components/comp-166.tsx",
@@ -3237,7 +2659,6 @@
     {
       "name": "comp-167",
       "type": "registry:component",
-      "registryDependencies": ["https://originui.com/r/radio-group.json"],
       "files": [
         {
           "path": "registry/default/components/comp-167.tsx",
@@ -3251,7 +2672,6 @@
     {
       "name": "comp-168",
       "type": "registry:component",
-      "registryDependencies": ["https://originui.com/r/radio-group.json"],
       "files": [
         {
           "path": "registry/default/components/comp-168.tsx",
@@ -3265,7 +2685,6 @@
     {
       "name": "comp-169",
       "type": "registry:component",
-      "registryDependencies": ["https://originui.com/r/radio-group.json"],
       "files": [
         {
           "path": "registry/default/components/comp-169.tsx",
@@ -3279,7 +2698,6 @@
     {
       "name": "comp-170",
       "type": "registry:component",
-      "registryDependencies": ["https://originui.com/r/radio-group.json"],
       "files": [
         {
           "path": "registry/default/components/comp-170.tsx",
@@ -3294,8 +2712,6 @@
     {
       "name": "comp-171",
       "type": "registry:component",
-      "registryDependencies": ["https://originui.com/r/radio-group.json"],
-      "dependencies": ["@remixicon/react"],
       "files": [
         {
           "path": "registry/default/components/comp-171.tsx",
@@ -3310,10 +2726,6 @@
     {
       "name": "comp-172",
       "type": "registry:component",
-      "registryDependencies": [
-        "https://originui.com/r/switch.json",
-        "https://originui.com/r/label.json"
-      ],
       "files": [
         {
           "path": "registry/default/components/comp-172.tsx",
@@ -3328,10 +2740,6 @@
     {
       "name": "comp-173",
       "type": "registry:component",
-      "registryDependencies": [
-        "https://originui.com/r/switch.json",
-        "https://originui.com/r/label.json"
-      ],
       "files": [
         {
           "path": "registry/default/components/comp-173.tsx",
@@ -3346,10 +2754,6 @@
     {
       "name": "comp-174",
       "type": "registry:component",
-      "registryDependencies": [
-        "https://originui.com/r/switch.json",
-        "https://originui.com/r/label.json"
-      ],
       "files": [
         {
           "path": "registry/default/components/comp-174.tsx",
@@ -3364,10 +2768,6 @@
     {
       "name": "comp-175",
       "type": "registry:component",
-      "registryDependencies": [
-        "https://originui.com/r/switch.json",
-        "https://originui.com/r/label.json"
-      ],
       "files": [
         {
           "path": "registry/default/components/comp-175.tsx",
@@ -3382,10 +2782,6 @@
     {
       "name": "comp-176",
       "type": "registry:component",
-      "registryDependencies": [
-        "https://originui.com/r/switch.json",
-        "https://originui.com/r/label.json"
-      ],
       "files": [
         {
           "path": "registry/default/components/comp-176.tsx",
@@ -3400,10 +2796,6 @@
     {
       "name": "comp-177",
       "type": "registry:component",
-      "registryDependencies": [
-        "https://originui.com/r/switch.json",
-        "https://originui.com/r/label.json"
-      ],
       "files": [
         {
           "path": "registry/default/components/comp-177.tsx",
@@ -3418,10 +2810,6 @@
     {
       "name": "comp-178",
       "type": "registry:component",
-      "registryDependencies": [
-        "https://originui.com/r/switch.json",
-        "https://originui.com/r/label.json"
-      ],
       "files": [
         {
           "path": "registry/default/components/comp-178.tsx",
@@ -3436,10 +2824,6 @@
     {
       "name": "comp-179",
       "type": "registry:component",
-      "registryDependencies": [
-        "https://originui.com/r/switch.json",
-        "https://originui.com/r/label.json"
-      ],
       "files": [
         {
           "path": "registry/default/components/comp-179.tsx",
@@ -3454,7 +2838,6 @@
     {
       "name": "comp-180",
       "type": "registry:component",
-      "registryDependencies": ["https://originui.com/r/switch.json"],
       "files": [
         {
           "path": "registry/default/components/comp-180.tsx",
@@ -3469,10 +2852,6 @@
     {
       "name": "comp-181",
       "type": "registry:component",
-      "registryDependencies": [
-        "https://originui.com/r/switch.json",
-        "https://originui.com/r/label.json"
-      ],
       "files": [
         {
           "path": "registry/default/components/comp-181.tsx",
@@ -3487,7 +2866,6 @@
     {
       "name": "comp-182",
       "type": "registry:component",
-      "registryDependencies": ["https://originui.com/r/switch.json"],
       "files": [
         {
           "path": "registry/default/components/comp-182.tsx",
@@ -3502,10 +2880,6 @@
     {
       "name": "comp-183",
       "type": "registry:component",
-      "registryDependencies": [
-        "https://originui.com/r/switch.json",
-        "https://originui.com/r/label.json"
-      ],
       "files": [
         {
           "path": "registry/default/components/comp-183.tsx",
@@ -3520,10 +2894,6 @@
     {
       "name": "comp-184",
       "type": "registry:component",
-      "registryDependencies": [
-        "https://originui.com/r/switch.json",
-        "https://originui.com/r/label.json"
-      ],
       "files": [
         {
           "path": "registry/default/components/comp-184.tsx",
@@ -3538,10 +2908,6 @@
     {
       "name": "comp-185",
       "type": "registry:component",
-      "registryDependencies": [
-        "https://originui.com/r/switch.json",
-        "https://originui.com/r/label.json"
-      ],
       "files": [
         {
           "path": "registry/default/components/comp-185.tsx",
@@ -3556,10 +2922,6 @@
     {
       "name": "comp-186",
       "type": "registry:component",
-      "registryDependencies": [
-        "https://originui.com/r/switch.json",
-        "https://originui.com/r/label.json"
-      ],
       "files": [
         {
           "path": "registry/default/components/comp-186.tsx",
@@ -3574,10 +2936,6 @@
     {
       "name": "comp-187",
       "type": "registry:component",
-      "registryDependencies": [
-        "https://originui.com/r/switch.json",
-        "https://originui.com/r/label.json"
-      ],
       "files": [
         {
           "path": "registry/default/components/comp-187.tsx",
@@ -3592,10 +2950,6 @@
     {
       "name": "comp-188",
       "type": "registry:component",
-      "registryDependencies": [
-        "https://originui.com/r/switch.json",
-        "https://originui.com/r/label.json"
-      ],
       "files": [
         {
           "path": "registry/default/components/comp-188.tsx",
@@ -3610,10 +2964,6 @@
     {
       "name": "comp-189",
       "type": "registry:component",
-      "registryDependencies": [
-        "https://originui.com/r/select-native.json",
-        "https://originui.com/r/label.json"
-      ],
       "files": [
         {
           "path": "registry/default/components/comp-189.tsx",
@@ -3627,10 +2977,6 @@
     {
       "name": "comp-190",
       "type": "registry:component",
-      "registryDependencies": [
-        "https://originui.com/r/select-native.json",
-        "https://originui.com/r/label.json"
-      ],
       "files": [
         {
           "path": "registry/default/components/comp-190.tsx",
@@ -3644,10 +2990,6 @@
     {
       "name": "comp-191",
       "type": "registry:component",
-      "registryDependencies": [
-        "https://originui.com/r/select-native.json",
-        "https://originui.com/r/label.json"
-      ],
       "files": [
         {
           "path": "registry/default/components/comp-191.tsx",
@@ -3661,10 +3003,6 @@
     {
       "name": "comp-192",
       "type": "registry:component",
-      "registryDependencies": [
-        "https://originui.com/r/select-native.json",
-        "https://originui.com/r/label.json"
-      ],
       "files": [
         {
           "path": "registry/default/components/comp-192.tsx",
@@ -3678,10 +3016,6 @@
     {
       "name": "comp-193",
       "type": "registry:component",
-      "registryDependencies": [
-        "https://originui.com/r/select-native.json",
-        "https://originui.com/r/label.json"
-      ],
       "files": [
         {
           "path": "registry/default/components/comp-193.tsx",
@@ -3695,10 +3029,6 @@
     {
       "name": "comp-194",
       "type": "registry:component",
-      "registryDependencies": [
-        "https://originui.com/r/select-native.json",
-        "https://originui.com/r/label.json"
-      ],
       "files": [
         {
           "path": "registry/default/components/comp-194.tsx",
@@ -3712,10 +3042,6 @@
     {
       "name": "comp-195",
       "type": "registry:component",
-      "registryDependencies": [
-        "https://originui.com/r/select-native.json",
-        "https://originui.com/r/label.json"
-      ],
       "files": [
         {
           "path": "registry/default/components/comp-195.tsx",
@@ -3729,10 +3055,6 @@
     {
       "name": "comp-196",
       "type": "registry:component",
-      "registryDependencies": [
-        "https://originui.com/r/select-native.json",
-        "https://originui.com/r/label.json"
-      ],
       "files": [
         {
           "path": "registry/default/components/comp-196.tsx",
@@ -3746,10 +3068,6 @@
     {
       "name": "comp-197",
       "type": "registry:component",
-      "registryDependencies": [
-        "https://originui.com/r/select-native.json",
-        "https://originui.com/r/label.json"
-      ],
       "files": [
         {
           "path": "registry/default/components/comp-197.tsx",
@@ -3763,10 +3081,6 @@
     {
       "name": "comp-198",
       "type": "registry:component",
-      "registryDependencies": [
-        "https://originui.com/r/select-native.json",
-        "https://originui.com/r/label.json"
-      ],
       "files": [
         {
           "path": "registry/default/components/comp-198.tsx",
@@ -3780,10 +3094,6 @@
     {
       "name": "comp-199",
       "type": "registry:component",
-      "registryDependencies": [
-        "https://originui.com/r/select-native.json",
-        "https://originui.com/r/label.json"
-      ],
       "files": [
         {
           "path": "registry/default/components/comp-199.tsx",
@@ -3797,10 +3107,6 @@
     {
       "name": "comp-200",
       "type": "registry:component",
-      "registryDependencies": [
-        "https://originui.com/r/select-native.json",
-        "https://originui.com/r/label.json"
-      ],
       "files": [
         {
           "path": "registry/default/components/comp-200.tsx",
@@ -3814,7 +3120,6 @@
     {
       "name": "comp-201",
       "type": "registry:component",
-      "registryDependencies": ["https://originui.com/r/select-native.json"],
       "files": [
         {
           "path": "registry/default/components/comp-201.tsx",
@@ -3828,7 +3133,6 @@
     {
       "name": "comp-202",
       "type": "registry:component",
-      "registryDependencies": ["https://originui.com/r/select-native.json"],
       "files": [
         {
           "path": "registry/default/components/comp-202.tsx",
@@ -3842,10 +3146,6 @@
     {
       "name": "comp-203",
       "type": "registry:component",
-      "registryDependencies": [
-        "https://originui.com/r/select.json",
-        "https://originui.com/r/label.json"
-      ],
       "files": [
         {
           "path": "registry/default/components/comp-203.tsx",
@@ -3859,10 +3159,6 @@
     {
       "name": "comp-204",
       "type": "registry:component",
-      "registryDependencies": [
-        "https://originui.com/r/select.json",
-        "https://originui.com/r/label.json"
-      ],
       "files": [
         {
           "path": "registry/default/components/comp-204.tsx",
@@ -3876,10 +3172,6 @@
     {
       "name": "comp-205",
       "type": "registry:component",
-      "registryDependencies": [
-        "https://originui.com/r/select.json",
-        "https://originui.com/r/label.json"
-      ],
       "files": [
         {
           "path": "registry/default/components/comp-205.tsx",
@@ -3893,10 +3185,6 @@
     {
       "name": "comp-206",
       "type": "registry:component",
-      "registryDependencies": [
-        "https://originui.com/r/select.json",
-        "https://originui.com/r/label.json"
-      ],
       "files": [
         {
           "path": "registry/default/components/comp-206.tsx",
@@ -3910,10 +3198,6 @@
     {
       "name": "comp-207",
       "type": "registry:component",
-      "registryDependencies": [
-        "https://originui.com/r/select.json",
-        "https://originui.com/r/label.json"
-      ],
       "files": [
         {
           "path": "registry/default/components/comp-207.tsx",
@@ -3927,10 +3211,6 @@
     {
       "name": "comp-208",
       "type": "registry:component",
-      "registryDependencies": [
-        "https://originui.com/r/select.json",
-        "https://originui.com/r/label.json"
-      ],
       "files": [
         {
           "path": "registry/default/components/comp-208.tsx",
@@ -3944,10 +3224,6 @@
     {
       "name": "comp-209",
       "type": "registry:component",
-      "registryDependencies": [
-        "https://originui.com/r/select.json",
-        "https://originui.com/r/label.json"
-      ],
       "files": [
         {
           "path": "registry/default/components/comp-209.tsx",
@@ -3961,10 +3237,6 @@
     {
       "name": "comp-210",
       "type": "registry:component",
-      "registryDependencies": [
-        "https://originui.com/r/select.json",
-        "https://originui.com/r/label.json"
-      ],
       "files": [
         {
           "path": "registry/default/components/comp-210.tsx",
@@ -3978,10 +3250,6 @@
     {
       "name": "comp-211",
       "type": "registry:component",
-      "registryDependencies": [
-        "https://originui.com/r/select.json",
-        "https://originui.com/r/label.json"
-      ],
       "files": [
         {
           "path": "registry/default/components/comp-211.tsx",
@@ -3995,10 +3263,6 @@
     {
       "name": "comp-212",
       "type": "registry:component",
-      "registryDependencies": [
-        "https://originui.com/r/select.json",
-        "https://originui.com/r/label.json"
-      ],
       "files": [
         {
           "path": "registry/default/components/comp-212.tsx",
@@ -4012,10 +3276,6 @@
     {
       "name": "comp-213",
       "type": "registry:component",
-      "registryDependencies": [
-        "https://originui.com/r/select.json",
-        "https://originui.com/r/label.json"
-      ],
       "files": [
         {
           "path": "registry/default/components/comp-213.tsx",
@@ -4029,10 +3289,6 @@
     {
       "name": "comp-214",
       "type": "registry:component",
-      "registryDependencies": [
-        "https://originui.com/r/select.json",
-        "https://originui.com/r/label.json"
-      ],
       "files": [
         {
           "path": "registry/default/components/comp-214.tsx",
@@ -4046,10 +3302,6 @@
     {
       "name": "comp-215",
       "type": "registry:component",
-      "registryDependencies": [
-        "https://originui.com/r/select.json",
-        "https://originui.com/r/label.json"
-      ],
       "files": [
         {
           "path": "registry/default/components/comp-215.tsx",
@@ -4063,7 +3315,6 @@
     {
       "name": "comp-216",
       "type": "registry:component",
-      "registryDependencies": ["https://originui.com/r/select.json"],
       "files": [
         {
           "path": "registry/default/components/comp-216.tsx",
@@ -4077,7 +3328,6 @@
     {
       "name": "comp-217",
       "type": "registry:component",
-      "registryDependencies": ["https://originui.com/r/select.json"],
       "files": [
         {
           "path": "registry/default/components/comp-217.tsx",
@@ -4091,10 +3341,6 @@
     {
       "name": "comp-218",
       "type": "registry:component",
-      "registryDependencies": [
-        "https://originui.com/r/select.json",
-        "https://originui.com/r/label.json"
-      ],
       "files": [
         {
           "path": "registry/default/components/comp-218.tsx",
@@ -4108,10 +3354,6 @@
     {
       "name": "comp-219",
       "type": "registry:component",
-      "registryDependencies": [
-        "https://originui.com/r/select.json",
-        "https://originui.com/r/label.json"
-      ],
       "files": [
         {
           "path": "registry/default/components/comp-219.tsx",
@@ -4125,10 +3367,6 @@
     {
       "name": "comp-220",
       "type": "registry:component",
-      "registryDependencies": [
-        "https://originui.com/r/select.json",
-        "https://originui.com/r/label.json"
-      ],
       "files": [
         {
           "path": "registry/default/components/comp-220.tsx",
@@ -4142,10 +3380,6 @@
     {
       "name": "comp-221",
       "type": "registry:component",
-      "registryDependencies": [
-        "https://originui.com/r/select.json",
-        "https://originui.com/r/label.json"
-      ],
       "files": [
         {
           "path": "registry/default/components/comp-221.tsx",
@@ -4159,11 +3393,6 @@
     {
       "name": "comp-222",
       "type": "registry:component",
-      "registryDependencies": [
-        "https://originui.com/r/select.json",
-        "https://originui.com/r/label.json"
-      ],
-      "dependencies": ["@remixicon/react"],
       "files": [
         {
           "path": "registry/default/components/comp-222.tsx",
@@ -4177,11 +3406,6 @@
     {
       "name": "comp-223",
       "type": "registry:component",
-      "registryDependencies": [
-        "https://originui.com/r/select.json",
-        "https://originui.com/r/label.json"
-      ],
-      "dependencies": ["@remixicon/react"],
       "files": [
         {
           "path": "registry/default/components/comp-223.tsx",
@@ -4195,10 +3419,6 @@
     {
       "name": "comp-224",
       "type": "registry:component",
-      "registryDependencies": [
-        "https://originui.com/r/select.json",
-        "https://originui.com/r/label.json"
-      ],
       "files": [
         {
           "path": "registry/default/components/comp-224.tsx",
@@ -4212,10 +3432,6 @@
     {
       "name": "comp-225",
       "type": "registry:component",
-      "registryDependencies": [
-        "https://originui.com/r/select.json",
-        "https://originui.com/r/label.json"
-      ],
       "files": [
         {
           "path": "registry/default/components/comp-225.tsx",
@@ -4229,10 +3445,6 @@
     {
       "name": "comp-226",
       "type": "registry:component",
-      "registryDependencies": [
-        "https://originui.com/r/select.json",
-        "https://originui.com/r/label.json"
-      ],
       "files": [
         {
           "path": "registry/default/components/comp-226.tsx",
@@ -4246,10 +3458,6 @@
     {
       "name": "comp-227",
       "type": "registry:component",
-      "registryDependencies": [
-        "https://originui.com/r/select.json",
-        "https://originui.com/r/label.json"
-      ],
       "files": [
         {
           "path": "registry/default/components/comp-227.tsx",
@@ -4263,10 +3471,6 @@
     {
       "name": "comp-228",
       "type": "registry:component",
-      "registryDependencies": [
-        "https://originui.com/r/select.json",
-        "https://originui.com/r/label.json"
-      ],
       "files": [
         {
           "path": "registry/default/components/comp-228.tsx",
@@ -4280,12 +3484,6 @@
     {
       "name": "comp-229",
       "type": "registry:component",
-      "registryDependencies": [
-        "https://originui.com/r/button.json",
-        "https://originui.com/r/command.json",
-        "https://originui.com/r/label.json",
-        "https://originui.com/r/popover.json"
-      ],
       "files": [
         {
           "path": "registry/default/components/comp-229.tsx",
@@ -4293,27 +3491,12 @@
         }
       ],
       "meta": {
-        "tags": [
-          "label",
-          "select",
-          "command",
-          "combobox",
-          "popover",
-          "search",
-          "autocomplete",
-          "radix"
-        ]
+        "tags": ["label", "select", "command", "combobox", "popover", "search", "autocomplete", "radix"]
       }
     },
     {
       "name": "comp-230",
       "type": "registry:component",
-      "registryDependencies": [
-        "https://originui.com/r/button.json",
-        "https://originui.com/r/command.json",
-        "https://originui.com/r/label.json",
-        "https://originui.com/r/popover.json"
-      ],
       "files": [
         {
           "path": "registry/default/components/comp-230.tsx",
@@ -4321,27 +3504,12 @@
         }
       ],
       "meta": {
-        "tags": [
-          "label",
-          "select",
-          "command",
-          "combobox",
-          "popover",
-          "search",
-          "autocomplete",
-          "radix"
-        ]
+        "tags": ["label", "select", "command", "combobox", "popover", "search", "autocomplete", "radix"]
       }
     },
     {
       "name": "comp-231",
       "type": "registry:component",
-      "registryDependencies": [
-        "https://originui.com/r/button.json",
-        "https://originui.com/r/command.json",
-        "https://originui.com/r/label.json",
-        "https://originui.com/r/popover.json"
-      ],
       "files": [
         {
           "path": "registry/default/components/comp-231.tsx",
@@ -4349,29 +3517,12 @@
         }
       ],
       "meta": {
-        "tags": [
-          "label",
-          "select",
-          "command",
-          "combobox",
-          "popover",
-          "search",
-          "autocomplete",
-          "timezone",
-          "time",
-          "radix"
-        ]
+        "tags": ["label", "select", "command", "combobox", "popover", "search", "autocomplete", "timezone", "time", "radix"]
       }
     },
     {
       "name": "comp-232",
       "type": "registry:component",
-      "registryDependencies": [
-        "https://originui.com/r/button.json",
-        "https://originui.com/r/command.json",
-        "https://originui.com/r/label.json",
-        "https://originui.com/r/popover.json"
-      ],
       "files": [
         {
           "path": "registry/default/components/comp-232.tsx",
@@ -4379,28 +3530,12 @@
         }
       ],
       "meta": {
-        "tags": [
-          "label",
-          "select",
-          "command",
-          "combobox",
-          "popover",
-          "search",
-          "autocomplete",
-          "flag",
-          "radix"
-        ]
+        "tags": ["label", "select", "command", "combobox", "popover", "search", "autocomplete", "flag", "radix"]
       }
     },
     {
       "name": "comp-233",
       "type": "registry:component",
-      "registryDependencies": [
-        "https://originui.com/r/button.json",
-        "https://originui.com/r/command.json",
-        "https://originui.com/r/label.json",
-        "https://originui.com/r/popover.json"
-      ],
       "files": [
         {
           "path": "registry/default/components/comp-233.tsx",
@@ -4408,25 +3543,12 @@
         }
       ],
       "meta": {
-        "tags": [
-          "label",
-          "select",
-          "command",
-          "combobox",
-          "popover",
-          "search",
-          "autocomplete",
-          "radix"
-        ]
+        "tags": ["label", "select", "command", "combobox", "popover", "search", "autocomplete", "radix"]
       }
     },
     {
       "name": "comp-234",
       "type": "registry:component",
-      "registryDependencies": [
-        "https://originui.com/r/label.json",
-        "https://originui.com/r/multiselect.json"
-      ],
       "files": [
         {
           "path": "registry/default/components/comp-234.tsx",
@@ -4434,25 +3556,12 @@
         }
       ],
       "meta": {
-        "tags": [
-          "label",
-          "select",
-          "multiselect",
-          "tag",
-          "input",
-          "search",
-          "autocomplete",
-          "radix"
-        ]
+        "tags": ["label", "select", "multiselect", "tag", "input", "search", "autocomplete", "radix"]
       }
     },
     {
       "name": "comp-235",
       "type": "registry:component",
-      "registryDependencies": [
-        "https://originui.com/r/label.json",
-        "https://originui.com/r/multiselect.json"
-      ],
       "files": [
         {
           "path": "registry/default/components/comp-235.tsx",
@@ -4460,25 +3569,12 @@
         }
       ],
       "meta": {
-        "tags": [
-          "label",
-          "select",
-          "multiselect",
-          "tag",
-          "input",
-          "search",
-          "autocomplete",
-          "radix"
-        ]
+        "tags": ["label", "select", "multiselect", "tag", "input", "search", "autocomplete", "radix"]
       }
     },
     {
       "name": "comp-236",
       "type": "registry:component",
-      "registryDependencies": [
-        "https://originui.com/r/label.json",
-        "https://originui.com/r/select-native.json"
-      ],
       "files": [
         {
           "path": "registry/default/components/comp-236.tsx",
@@ -4492,8 +3588,6 @@
     {
       "name": "comp-237",
       "type": "registry:component",
-      "registryDependencies": ["https://originui.com/r/label.json"],
-      "dependencies": ["react-aria-components"],
       "files": [
         {
           "path": "registry/default/components/comp-237.tsx",
@@ -4507,8 +3601,6 @@
     {
       "name": "comp-238",
       "type": "registry:component",
-      "registryDependencies": ["https://originui.com/r/label.json"],
-      "dependencies": ["react-aria-components"],
       "files": [
         {
           "path": "registry/default/components/comp-238.tsx",
@@ -4522,8 +3614,6 @@
     {
       "name": "comp-239",
       "type": "registry:component",
-      "registryDependencies": ["https://originui.com/r/label.json"],
-      "dependencies": ["react-aria-components"],
       "files": [
         {
           "path": "registry/default/components/comp-239.tsx",
@@ -4537,10 +3627,6 @@
     {
       "name": "comp-240",
       "type": "registry:component",
-      "registryDependencies": [
-        "https://originui.com/r/label.json",
-        "https://originui.com/r/slider.json"
-      ],
       "files": [
         {
           "path": "registry/default/components/comp-240.tsx",
@@ -4554,10 +3640,6 @@
     {
       "name": "comp-241",
       "type": "registry:component",
-      "registryDependencies": [
-        "https://originui.com/r/label.json",
-        "https://originui.com/r/slider.json"
-      ],
       "files": [
         {
           "path": "registry/default/components/comp-241.tsx",
@@ -4571,10 +3653,6 @@
     {
       "name": "comp-242",
       "type": "registry:component",
-      "registryDependencies": [
-        "https://originui.com/r/label.json",
-        "https://originui.com/r/slider.json"
-      ],
       "files": [
         {
           "path": "registry/default/components/comp-242.tsx",
@@ -4588,10 +3666,6 @@
     {
       "name": "comp-243",
       "type": "registry:component",
-      "registryDependencies": [
-        "https://originui.com/r/label.json",
-        "https://originui.com/r/slider.json"
-      ],
       "files": [
         {
           "path": "registry/default/components/comp-243.tsx",
@@ -4605,10 +3679,6 @@
     {
       "name": "comp-244",
       "type": "registry:component",
-      "registryDependencies": [
-        "https://originui.com/r/label.json",
-        "https://originui.com/r/slider.json"
-      ],
       "files": [
         {
           "path": "registry/default/components/comp-244.tsx",
@@ -4622,10 +3692,6 @@
     {
       "name": "comp-245",
       "type": "registry:component",
-      "registryDependencies": [
-        "https://originui.com/r/label.json",
-        "https://originui.com/r/slider.json"
-      ],
       "files": [
         {
           "path": "registry/default/components/comp-245.tsx",
@@ -4639,10 +3705,6 @@
     {
       "name": "comp-246",
       "type": "registry:component",
-      "registryDependencies": [
-        "https://originui.com/r/label.json",
-        "https://originui.com/r/slider.json"
-      ],
       "files": [
         {
           "path": "registry/default/components/comp-246.tsx",
@@ -4656,10 +3718,6 @@
     {
       "name": "comp-247",
       "type": "registry:component",
-      "registryDependencies": [
-        "https://originui.com/r/label.json",
-        "https://originui.com/r/slider.json"
-      ],
       "files": [
         {
           "path": "registry/default/components/comp-247.tsx",
@@ -4673,10 +3731,6 @@
     {
       "name": "comp-248",
       "type": "registry:component",
-      "registryDependencies": [
-        "https://originui.com/r/label.json",
-        "https://originui.com/r/slider.json"
-      ],
       "files": [
         {
           "path": "registry/default/components/comp-248.tsx",
@@ -4690,10 +3744,6 @@
     {
       "name": "comp-249",
       "type": "registry:component",
-      "registryDependencies": [
-        "https://originui.com/r/label.json",
-        "https://originui.com/r/slider.json"
-      ],
       "files": [
         {
           "path": "registry/default/components/comp-249.tsx",
@@ -4707,10 +3757,6 @@
     {
       "name": "comp-250",
       "type": "registry:component",
-      "registryDependencies": [
-        "https://originui.com/r/label.json",
-        "https://originui.com/r/slider.json"
-      ],
       "files": [
         {
           "path": "registry/default/components/comp-250.tsx",
@@ -4724,10 +3770,6 @@
     {
       "name": "comp-251",
       "type": "registry:component",
-      "registryDependencies": [
-        "https://originui.com/r/label.json",
-        "https://originui.com/r/slider.json"
-      ],
       "files": [
         {
           "path": "registry/default/components/comp-251.tsx",
@@ -4741,10 +3783,6 @@
     {
       "name": "comp-252",
       "type": "registry:component",
-      "registryDependencies": [
-        "https://originui.com/r/label.json",
-        "https://originui.com/r/slider.json"
-      ],
       "files": [
         {
           "path": "registry/default/components/comp-252.tsx",
@@ -4758,10 +3796,6 @@
     {
       "name": "comp-253",
       "type": "registry:component",
-      "registryDependencies": [
-        "https://originui.com/r/label.json",
-        "https://originui.com/r/slider.json"
-      ],
       "files": [
         {
           "path": "registry/default/components/comp-253.tsx",
@@ -4775,21 +3809,10 @@
     {
       "name": "comp-254",
       "type": "registry:component",
-      "registryDependencies": [
-        "https://originui.com/r/button.json",
-        "https://originui.com/r/input.json",
-        "https://originui.com/r/label.json",
-        "https://originui.com/r/slider.json",
-        "https://originui.com/r/tooltip.json"
-      ],
       "files": [
         {
           "path": "registry/default/components/comp-254.tsx",
           "type": "registry:component"
-        },
-        {
-          "path": "registry/default/hooks/use-slider-with-input.ts",
-          "type": "registry:hook"
         }
       ],
       "meta": {
@@ -4799,19 +3822,10 @@
     {
       "name": "comp-255",
       "type": "registry:component",
-      "registryDependencies": [
-        "https://originui.com/r/input.json",
-        "https://originui.com/r/label.json",
-        "https://originui.com/r/slider.json"
-      ],
       "files": [
         {
           "path": "registry/default/components/comp-255.tsx",
           "type": "registry:component"
-        },
-        {
-          "path": "registry/default/hooks/use-slider-with-input.ts",
-          "type": "registry:hook"
         }
       ],
       "meta": {
@@ -4821,10 +3835,6 @@
     {
       "name": "comp-256",
       "type": "registry:component",
-      "registryDependencies": [
-        "https://originui.com/r/label.json",
-        "https://originui.com/r/slider.json"
-      ],
       "files": [
         {
           "path": "registry/default/components/comp-256.tsx",
@@ -4838,10 +3848,6 @@
     {
       "name": "comp-257",
       "type": "registry:component",
-      "registryDependencies": [
-        "https://originui.com/r/label.json",
-        "https://originui.com/r/slider.json"
-      ],
       "files": [
         {
           "path": "registry/default/components/comp-257.tsx",
@@ -4855,19 +3861,10 @@
     {
       "name": "comp-258",
       "type": "registry:component",
-      "registryDependencies": [
-        "https://originui.com/r/input.json",
-        "https://originui.com/r/label.json",
-        "https://originui.com/r/slider.json"
-      ],
       "files": [
         {
           "path": "registry/default/components/comp-258.tsx",
           "type": "registry:component"
-        },
-        {
-          "path": "registry/default/hooks/use-slider-with-input.ts",
-          "type": "registry:hook"
         }
       ],
       "meta": {
@@ -4877,11 +3874,6 @@
     {
       "name": "comp-259",
       "type": "registry:component",
-      "registryDependencies": [
-        "https://originui.com/r/button.json",
-        "https://originui.com/r/label.json",
-        "https://originui.com/r/slider.json"
-      ],
       "files": [
         {
           "path": "registry/default/components/comp-259.tsx",
@@ -4895,11 +3887,6 @@
     {
       "name": "comp-260",
       "type": "registry:component",
-      "registryDependencies": [
-        "https://originui.com/r/button.json",
-        "https://originui.com/r/label.json",
-        "https://originui.com/r/slider.json"
-      ],
       "files": [
         {
           "path": "registry/default/components/comp-260.tsx",
@@ -4913,10 +3900,6 @@
     {
       "name": "comp-261",
       "type": "registry:component",
-      "registryDependencies": [
-        "https://originui.com/r/label.json",
-        "https://originui.com/r/slider.json"
-      ],
       "files": [
         {
           "path": "registry/default/components/comp-261.tsx",
@@ -4930,19 +3913,10 @@
     {
       "name": "comp-262",
       "type": "registry:component",
-      "registryDependencies": [
-        "https://originui.com/r/label.json",
-        "https://originui.com/r/slider.json",
-        "https://originui.com/r/input.json"
-      ],
       "files": [
         {
           "path": "registry/default/components/comp-262.tsx",
           "type": "registry:component"
-        },
-        {
-          "path": "registry/default/hooks/use-slider-with-input.ts",
-          "type": "registry:hook"
         }
       ],
       "meta": {
@@ -4952,10 +3926,6 @@
     {
       "name": "comp-263",
       "type": "registry:component",
-      "registryDependencies": [
-        "https://originui.com/r/label.json",
-        "https://originui.com/r/slider.json"
-      ],
       "files": [
         {
           "path": "registry/default/components/comp-263.tsx",
@@ -4969,20 +3939,10 @@
     {
       "name": "comp-264",
       "type": "registry:component",
-      "registryDependencies": [
-        "https://originui.com/r/label.json",
-        "https://originui.com/r/slider.json",
-        "https://originui.com/r/input.json",
-        "https://originui.com/r/button.json"
-      ],
       "files": [
         {
           "path": "registry/default/components/comp-264.tsx",
           "type": "registry:component"
-        },
-        {
-          "path": "registry/default/hooks/use-slider-with-input.ts",
-          "type": "registry:hook"
         }
       ],
       "meta": {
@@ -4992,20 +3952,10 @@
     {
       "name": "comp-265",
       "type": "registry:component",
-      "registryDependencies": [
-        "https://originui.com/r/label.json",
-        "https://originui.com/r/slider.json",
-        "https://originui.com/r/input.json",
-        "https://originui.com/r/button.json"
-      ],
       "files": [
         {
           "path": "registry/default/components/comp-265.tsx",
           "type": "registry:component"
-        },
-        {
-          "path": "registry/default/hooks/use-slider-with-input.ts",
-          "type": "registry:hook"
         }
       ],
       "meta": {
@@ -5015,10 +3965,6 @@
     {
       "name": "comp-266",
       "type": "registry:component",
-      "registryDependencies": [
-        "https://originui.com/r/label.json",
-        "https://originui.com/r/slider.json"
-      ],
       "files": [
         {
           "path": "registry/default/components/comp-266.tsx",
@@ -5200,7 +4146,6 @@
     {
       "name": "comp-279",
       "type": "registry:component",
-      "registryDependencies": ["https://originui.com/r/button.json"],
       "files": [
         {
           "path": "registry/default/components/comp-279.tsx",
@@ -5216,7 +4161,6 @@
     {
       "name": "comp-280",
       "type": "registry:component",
-      "registryDependencies": ["https://originui.com/r/button.json"],
       "files": [
         {
           "path": "registry/default/components/comp-280.tsx",
@@ -5232,7 +4176,6 @@
     {
       "name": "comp-281",
       "type": "registry:component",
-      "registryDependencies": ["https://originui.com/r/button.json"],
       "files": [
         {
           "path": "registry/default/components/comp-281.tsx",
@@ -5248,7 +4191,6 @@
     {
       "name": "comp-282",
       "type": "registry:component",
-      "registryDependencies": ["https://originui.com/r/button.json"],
       "files": [
         {
           "path": "registry/default/components/comp-282.tsx",
@@ -5264,7 +4206,6 @@
     {
       "name": "comp-283",
       "type": "registry:component",
-      "registryDependencies": ["https://originui.com/r/button.json"],
       "files": [
         {
           "path": "registry/default/components/comp-283.tsx",
@@ -5280,7 +4221,6 @@
     {
       "name": "comp-284",
       "type": "registry:component",
-      "registryDependencies": ["https://originui.com/r/button.json"],
       "files": [
         {
           "path": "registry/default/components/comp-284.tsx",
@@ -5296,7 +4236,6 @@
     {
       "name": "comp-285",
       "type": "registry:component",
-      "registryDependencies": ["https://originui.com/r/button.json"],
       "files": [
         {
           "path": "registry/default/components/comp-285.tsx",
@@ -5312,7 +4251,6 @@
     {
       "name": "comp-286",
       "type": "registry:component",
-      "registryDependencies": ["https://originui.com/r/button.json"],
       "files": [
         {
           "path": "registry/default/components/comp-286.tsx",
@@ -5328,7 +4266,6 @@
     {
       "name": "comp-287",
       "type": "registry:component",
-      "registryDependencies": ["https://originui.com/r/button.json"],
       "files": [
         {
           "path": "registry/default/components/comp-287.tsx",
@@ -5344,7 +4281,6 @@
     {
       "name": "comp-288",
       "type": "registry:component",
-      "registryDependencies": ["https://originui.com/r/button.json"],
       "files": [
         {
           "path": "registry/default/components/comp-288.tsx",
@@ -5360,7 +4296,6 @@
     {
       "name": "comp-289",
       "type": "registry:component",
-      "registryDependencies": ["https://originui.com/r/button.json"],
       "files": [
         {
           "path": "registry/default/components/comp-289.tsx",
@@ -5376,7 +4311,6 @@
     {
       "name": "comp-290",
       "type": "registry:component",
-      "registryDependencies": ["https://originui.com/r/button.json"],
       "files": [
         {
           "path": "registry/default/components/comp-290.tsx",
@@ -5392,7 +4326,6 @@
     {
       "name": "comp-291",
       "type": "registry:component",
-      "registryDependencies": ["https://originui.com/r/button.json"],
       "files": [
         {
           "path": "registry/default/components/comp-291.tsx",
@@ -5408,7 +4341,6 @@
     {
       "name": "comp-292",
       "type": "registry:component",
-      "registryDependencies": ["https://originui.com/r/button.json"],
       "files": [
         {
           "path": "registry/default/components/comp-292.tsx",
@@ -5424,7 +4356,6 @@
     {
       "name": "comp-293",
       "type": "registry:component",
-      "registryDependencies": ["https://originui.com/r/button.json"],
       "files": [
         {
           "path": "registry/default/components/comp-293.tsx",
@@ -5440,7 +4371,6 @@
     {
       "name": "comp-294",
       "type": "registry:component",
-      "registryDependencies": ["https://originui.com/r/button.json"],
       "files": [
         {
           "path": "registry/default/components/comp-294.tsx",
@@ -5456,7 +4386,6 @@
     {
       "name": "comp-295",
       "type": "registry:component",
-      "registryDependencies": ["https://originui.com/r/button.json"],
       "files": [
         {
           "path": "registry/default/components/comp-295.tsx",
@@ -5472,7 +4401,6 @@
     {
       "name": "comp-296",
       "type": "registry:component",
-      "registryDependencies": ["https://originui.com/r/button.json"],
       "files": [
         {
           "path": "registry/default/components/comp-296.tsx",
@@ -5488,18 +4416,10 @@
     {
       "name": "comp-297",
       "type": "registry:component",
-      "registryDependencies": [
-        "https://originui.com/r/button.json",
-        "https://originui.com/r/toast.json"
-      ],
       "files": [
         {
           "path": "registry/default/components/comp-297.tsx",
           "type": "registry:component"
-        },
-        {
-          "path": "registry/default/hooks/use-toast.ts",
-          "type": "registry:hook"
         }
       ],
       "meta": {
@@ -5511,10 +4431,6 @@
     {
       "name": "comp-298",
       "type": "registry:component",
-      "registryDependencies": [
-        "https://originui.com/r/button.json",
-        "https://originui.com/r/toast.json"
-      ],
       "files": [
         {
           "path": "registry/default/components/comp-298.tsx",
@@ -5530,8 +4446,6 @@
     {
       "name": "comp-299",
       "type": "registry:component",
-      "registryDependencies": ["https://originui.com/r/button.json"],
-      "dependencies": ["sonner"],
       "files": [
         {
           "path": "registry/default/components/comp-299.tsx",
@@ -5547,8 +4461,6 @@
     {
       "name": "comp-300",
       "type": "registry:component",
-      "registryDependencies": ["https://originui.com/r/button.json"],
-      "dependencies": ["sonner"],
       "files": [
         {
           "path": "registry/default/components/comp-300.tsx",
@@ -5564,7 +4476,6 @@
     {
       "name": "comp-301",
       "type": "registry:component",
-      "registryDependencies": ["https://originui.com/r/button.json"],
       "files": [
         {
           "path": "registry/default/components/comp-301.tsx",
@@ -5621,7 +4532,6 @@
     {
       "name": "comp-305",
       "type": "registry:component",
-      "registryDependencies": ["https://originui.com/r/button.json"],
       "files": [
         {
           "path": "registry/default/components/comp-305.tsx",
@@ -5636,7 +4546,6 @@
     {
       "name": "comp-306",
       "type": "registry:component",
-      "registryDependencies": ["https://originui.com/r/button.json"],
       "files": [
         {
           "path": "registry/default/components/comp-306.tsx",
@@ -5651,7 +4560,6 @@
     {
       "name": "comp-307",
       "type": "registry:component",
-      "registryDependencies": ["https://originui.com/r/button.json"],
       "files": [
         {
           "path": "registry/default/components/comp-307.tsx",
@@ -5666,7 +4574,6 @@
     {
       "name": "comp-308",
       "type": "registry:component",
-      "registryDependencies": ["https://originui.com/r/button.json"],
       "files": [
         {
           "path": "registry/default/components/comp-308.tsx",
@@ -5681,7 +4588,6 @@
     {
       "name": "comp-309",
       "type": "registry:component",
-      "registryDependencies": ["https://originui.com/r/button.json"],
       "files": [
         {
           "path": "registry/default/components/comp-309.tsx",
@@ -5696,7 +4602,6 @@
     {
       "name": "comp-310",
       "type": "registry:component",
-      "registryDependencies": ["https://originui.com/r/button.json"],
       "files": [
         {
           "path": "registry/default/components/comp-310.tsx",
@@ -5725,7 +4630,6 @@
     {
       "name": "comp-312",
       "type": "registry:component",
-      "registryDependencies": ["https://originui.com/r/button.json"],
       "files": [
         {
           "path": "registry/default/components/comp-312.tsx",
@@ -5740,10 +4644,6 @@
     {
       "name": "comp-313",
       "type": "registry:component",
-      "registryDependencies": [
-        "https://originui.com/r/alert-dialog.json",
-        "https://originui.com/r/button.json"
-      ],
       "files": [
         {
           "path": "registry/default/components/comp-313.tsx",
@@ -5758,10 +4658,6 @@
     {
       "name": "comp-314",
       "type": "registry:component",
-      "registryDependencies": [
-        "https://originui.com/r/alert-dialog.json",
-        "https://originui.com/r/button.json"
-      ],
       "files": [
         {
           "path": "registry/default/components/comp-314.tsx",
@@ -5776,10 +4672,6 @@
     {
       "name": "comp-315",
       "type": "registry:component",
-      "registryDependencies": [
-        "https://originui.com/r/button.json",
-        "https://originui.com/r/dialog.json"
-      ],
       "files": [
         {
           "path": "registry/default/components/comp-315.tsx",
@@ -5794,11 +4686,6 @@
     {
       "name": "comp-316",
       "type": "registry:component",
-      "registryDependencies": [
-        "https://originui.com/r/button.json",
-        "https://originui.com/r/dialog.json",
-        "https://originui.com/r/scroll-area.json"
-      ],
       "files": [
         {
           "path": "registry/default/components/comp-316.tsx",
@@ -5813,10 +4700,6 @@
     {
       "name": "comp-317",
       "type": "registry:component",
-      "registryDependencies": [
-        "https://originui.com/r/button.json",
-        "https://originui.com/r/dialog.json"
-      ],
       "files": [
         {
           "path": "registry/default/components/comp-317.tsx",
@@ -5831,10 +4714,6 @@
     {
       "name": "comp-318",
       "type": "registry:component",
-      "registryDependencies": [
-        "https://originui.com/r/button.json",
-        "https://originui.com/r/dialog.json"
-      ],
       "files": [
         {
           "path": "registry/default/components/comp-318.tsx",
@@ -5849,10 +4728,6 @@
     {
       "name": "comp-319",
       "type": "registry:component",
-      "registryDependencies": [
-        "https://originui.com/r/button.json",
-        "https://originui.com/r/dialog.json"
-      ],
       "files": [
         {
           "path": "registry/default/components/comp-319.tsx",
@@ -5867,12 +4742,6 @@
     {
       "name": "comp-320",
       "type": "registry:component",
-      "registryDependencies": [
-        "https://originui.com/r/button.json",
-        "https://originui.com/r/dialog.json",
-        "https://originui.com/r/input.json",
-        "https://originui.com/r/label.json"
-      ],
       "files": [
         {
           "path": "registry/default/components/comp-320.tsx",
@@ -5887,11 +4756,6 @@
     {
       "name": "comp-321",
       "type": "registry:component",
-      "registryDependencies": [
-        "https://originui.com/r/button.json",
-        "https://originui.com/r/dialog.json",
-        "https://originui.com/r/input.json"
-      ],
       "files": [
         {
           "path": "registry/default/components/comp-321.tsx",
@@ -5906,11 +4770,6 @@
     {
       "name": "comp-322",
       "type": "registry:component",
-      "registryDependencies": [
-        "https://originui.com/r/button.json",
-        "https://originui.com/r/dialog.json",
-        "https://originui.com/r/textarea.json"
-      ],
       "files": [
         {
           "path": "registry/default/components/comp-322.tsx",
@@ -5925,13 +4784,6 @@
     {
       "name": "comp-323",
       "type": "registry:component",
-      "registryDependencies": [
-        "https://originui.com/r/button.json",
-        "https://originui.com/r/dialog.json",
-        "https://originui.com/r/label.json",
-        "https://originui.com/r/radio-group.json",
-        "https://originui.com/r/textarea.json"
-      ],
       "files": [
         {
           "path": "registry/default/components/comp-323.tsx",
@@ -5946,11 +4798,6 @@
     {
       "name": "comp-324",
       "type": "registry:component",
-      "registryDependencies": [
-        "https://originui.com/r/button.json",
-        "https://originui.com/r/dialog.json"
-      ],
-      "dependencies": ["input-otp"],
       "files": [
         {
           "path": "registry/default/components/comp-324.tsx",
@@ -5965,12 +4812,6 @@
     {
       "name": "comp-325",
       "type": "registry:component",
-      "registryDependencies": [
-        "https://originui.com/r/button.json",
-        "https://originui.com/r/dialog.json",
-        "https://originui.com/r/input.json",
-        "https://originui.com/r/label.json"
-      ],
       "files": [
         {
           "path": "registry/default/components/comp-325.tsx",
@@ -5985,13 +4826,6 @@
     {
       "name": "comp-326",
       "type": "registry:component",
-      "registryDependencies": [
-        "https://originui.com/r/button.json",
-        "https://originui.com/r/checkbox.json",
-        "https://originui.com/r/dialog.json",
-        "https://originui.com/r/input.json",
-        "https://originui.com/r/label.json"
-      ],
       "files": [
         {
           "path": "registry/default/components/comp-326.tsx",
@@ -6006,13 +4840,6 @@
     {
       "name": "comp-327",
       "type": "registry:component",
-      "registryDependencies": [
-        "https://originui.com/r/button.json",
-        "https://originui.com/r/dialog.json",
-        "https://originui.com/r/input.json",
-        "https://originui.com/r/label.json",
-        "https://originui.com/r/tooltip.json"
-      ],
       "files": [
         {
           "path": "registry/default/components/comp-327.tsx",
@@ -6027,15 +4854,6 @@
     {
       "name": "comp-328",
       "type": "registry:component",
-      "registryDependencies": [
-        "https://originui.com/r/button.json",
-        "https://originui.com/r/checkbox.json",
-        "https://originui.com/r/dialog.json",
-        "https://originui.com/r/input.json",
-        "https://originui.com/r/label.json"
-      ],
-      "dependencies": ["react-payment-inputs"],
-      "devDependencies": ["@types/react-payment-inputs"],
       "files": [
         {
           "path": "registry/default/components/comp-328.tsx",
@@ -6050,16 +4868,6 @@
     {
       "name": "comp-329",
       "type": "registry:component",
-      "registryDependencies": [
-        "https://originui.com/r/badge.json",
-        "https://originui.com/r/button.json",
-        "https://originui.com/r/dialog.json",
-        "https://originui.com/r/input.json",
-        "https://originui.com/r/label.json",
-        "https://originui.com/r/radio-group.json"
-      ],
-      "dependencies": ["react-payment-inputs"],
-      "devDependencies": ["@types/react-payment-inputs"],
       "files": [
         {
           "path": "registry/default/components/comp-329.tsx",
@@ -6074,12 +4882,6 @@
     {
       "name": "comp-330",
       "type": "registry:component",
-      "registryDependencies": [
-        "https://originui.com/r/button.json",
-        "https://originui.com/r/dialog.json",
-        "https://originui.com/r/label.json",
-        "https://originui.com/r/radio-group.json"
-      ],
       "files": [
         {
           "path": "registry/default/components/comp-330.tsx",
@@ -6094,25 +4896,10 @@
     {
       "name": "comp-331",
       "type": "registry:component",
-      "registryDependencies": [
-        "https://originui.com/r/button.json",
-        "https://originui.com/r/dialog.json",
-        "https://originui.com/r/input.json",
-        "https://originui.com/r/label.json",
-        "https://originui.com/r/textarea.json"
-      ],
       "files": [
         {
           "path": "registry/default/components/comp-331.tsx",
           "type": "registry:component"
-        },
-        {
-          "path": "registry/default/hooks/use-character-limit.ts",
-          "type": "registry:hook"
-        },
-        {
-          "path": "registry/default/hooks/use-file-upload.ts",
-          "type": "registry:hook"
         }
       ],
       "meta": {
@@ -6123,10 +4910,6 @@
     {
       "name": "comp-332",
       "type": "registry:component",
-      "registryDependencies": [
-        "https://originui.com/r/button.json",
-        "https://originui.com/r/dialog.json"
-      ],
       "files": [
         {
           "path": "registry/default/components/comp-332.tsx",
@@ -6141,7 +4924,6 @@
     {
       "name": "comp-333",
       "type": "registry:component",
-      "registryDependencies": ["https://originui.com/r/command.json"],
       "files": [
         {
           "path": "registry/default/components/comp-333.tsx",
@@ -6149,24 +4931,13 @@
         }
       ],
       "meta": {
-        "tags": [
-          "dialog",
-          "modal",
-          "command",
-          "combobox",
-          "popover",
-          "search",
-          "radix",
-          "autocomplete",
-          "radix"
-        ],
+        "tags": ["dialog", "modal", "command", "combobox", "popover", "search", "radix", "autocomplete", "radix"],
         "style": 1
       }
     },
     {
       "name": "comp-334",
       "type": "registry:component",
-      "registryDependencies": ["https://originui.com/r/accordion.json"],
       "files": [
         {
           "path": "registry/default/components/comp-334.tsx",
@@ -6181,7 +4952,6 @@
     {
       "name": "comp-335",
       "type": "registry:component",
-      "registryDependencies": ["https://originui.com/r/accordion.json"],
       "files": [
         {
           "path": "registry/default/components/comp-335.tsx",
@@ -6196,7 +4966,6 @@
     {
       "name": "comp-336",
       "type": "registry:component",
-      "registryDependencies": ["https://originui.com/r/accordion.json"],
       "files": [
         {
           "path": "registry/default/components/comp-336.tsx",
@@ -6211,7 +4980,6 @@
     {
       "name": "comp-337",
       "type": "registry:component",
-      "registryDependencies": ["https://originui.com/r/accordion.json"],
       "files": [
         {
           "path": "registry/default/components/comp-337.tsx",
@@ -6226,7 +4994,6 @@
     {
       "name": "comp-338",
       "type": "registry:component",
-      "registryDependencies": ["https://originui.com/r/accordion.json"],
       "files": [
         {
           "path": "registry/default/components/comp-338.tsx",
@@ -6241,7 +5008,6 @@
     {
       "name": "comp-339",
       "type": "registry:component",
-      "registryDependencies": ["https://originui.com/r/accordion.json"],
       "files": [
         {
           "path": "registry/default/components/comp-339.tsx",
@@ -6256,7 +5022,6 @@
     {
       "name": "comp-340",
       "type": "registry:component",
-      "registryDependencies": ["https://originui.com/r/accordion.json"],
       "files": [
         {
           "path": "registry/default/components/comp-340.tsx",
@@ -6271,7 +5036,6 @@
     {
       "name": "comp-341",
       "type": "registry:component",
-      "registryDependencies": ["https://originui.com/r/accordion.json"],
       "files": [
         {
           "path": "registry/default/components/comp-341.tsx",
@@ -6286,7 +5050,6 @@
     {
       "name": "comp-342",
       "type": "registry:component",
-      "registryDependencies": ["https://originui.com/r/accordion.json"],
       "files": [
         {
           "path": "registry/default/components/comp-342.tsx",
@@ -6301,7 +5064,6 @@
     {
       "name": "comp-343",
       "type": "registry:component",
-      "registryDependencies": ["https://originui.com/r/accordion.json"],
       "files": [
         {
           "path": "registry/default/components/comp-343.tsx",
@@ -6316,7 +5078,6 @@
     {
       "name": "comp-344",
       "type": "registry:component",
-      "registryDependencies": ["https://originui.com/r/accordion.json"],
       "files": [
         {
           "path": "registry/default/components/comp-344.tsx",
@@ -6331,7 +5092,6 @@
     {
       "name": "comp-345",
       "type": "registry:component",
-      "registryDependencies": ["https://originui.com/r/accordion.json"],
       "files": [
         {
           "path": "registry/default/components/comp-345.tsx",
@@ -6346,7 +5106,6 @@
     {
       "name": "comp-346",
       "type": "registry:component",
-      "registryDependencies": ["https://originui.com/r/accordion.json"],
       "files": [
         {
           "path": "registry/default/components/comp-346.tsx",
@@ -6361,7 +5120,6 @@
     {
       "name": "comp-347",
       "type": "registry:component",
-      "registryDependencies": ["https://originui.com/r/accordion.json"],
       "files": [
         {
           "path": "registry/default/components/comp-347.tsx",
@@ -6376,7 +5134,6 @@
     {
       "name": "comp-348",
       "type": "registry:component",
-      "registryDependencies": ["https://originui.com/r/accordion.json"],
       "files": [
         {
           "path": "registry/default/components/comp-348.tsx",
@@ -6391,7 +5148,6 @@
     {
       "name": "comp-349",
       "type": "registry:component",
-      "registryDependencies": ["https://originui.com/r/accordion.json"],
       "files": [
         {
           "path": "registry/default/components/comp-349.tsx",
@@ -6406,7 +5162,6 @@
     {
       "name": "comp-350",
       "type": "registry:component",
-      "registryDependencies": ["https://originui.com/r/accordion.json"],
       "files": [
         {
           "path": "registry/default/components/comp-350.tsx",
@@ -6421,7 +5176,6 @@
     {
       "name": "comp-351",
       "type": "registry:component",
-      "registryDependencies": ["https://originui.com/r/accordion.json"],
       "files": [
         {
           "path": "registry/default/components/comp-351.tsx",
@@ -6436,10 +5190,6 @@
     {
       "name": "comp-352",
       "type": "registry:component",
-      "registryDependencies": [
-        "https://originui.com/r/accordion.json",
-        "https://originui.com/r/collapsible.json"
-      ],
       "files": [
         {
           "path": "registry/default/components/comp-352.tsx",
@@ -6454,10 +5204,6 @@
     {
       "name": "comp-353",
       "type": "registry:component",
-      "registryDependencies": [
-        "https://originui.com/r/accordion.json",
-        "https://originui.com/r/collapsible.json"
-      ],
       "files": [
         {
           "path": "registry/default/components/comp-353.tsx",
@@ -6472,10 +5218,6 @@
     {
       "name": "comp-354",
       "type": "registry:component",
-      "registryDependencies": [
-        "https://originui.com/r/button.json",
-        "https://originui.com/r/tooltip.json"
-      ],
       "files": [
         {
           "path": "registry/default/components/comp-354.tsx",
@@ -6490,10 +5232,6 @@
     {
       "name": "comp-355",
       "type": "registry:component",
-      "registryDependencies": [
-        "https://originui.com/r/button.json",
-        "https://originui.com/r/tooltip.json"
-      ],
       "files": [
         {
           "path": "registry/default/components/comp-355.tsx",
@@ -6508,10 +5246,6 @@
     {
       "name": "comp-356",
       "type": "registry:component",
-      "registryDependencies": [
-        "https://originui.com/r/button.json",
-        "https://originui.com/r/tooltip.json"
-      ],
       "files": [
         {
           "path": "registry/default/components/comp-356.tsx",
@@ -6526,10 +5260,6 @@
     {
       "name": "comp-357",
       "type": "registry:component",
-      "registryDependencies": [
-        "https://originui.com/r/button.json",
-        "https://originui.com/r/tooltip.json"
-      ],
       "files": [
         {
           "path": "registry/default/components/comp-357.tsx",
@@ -6544,10 +5274,6 @@
     {
       "name": "comp-358",
       "type": "registry:component",
-      "registryDependencies": [
-        "https://originui.com/r/button.json",
-        "https://originui.com/r/tooltip.json"
-      ],
       "files": [
         {
           "path": "registry/default/components/comp-358.tsx",
@@ -6562,10 +5288,6 @@
     {
       "name": "comp-359",
       "type": "registry:component",
-      "registryDependencies": [
-        "https://originui.com/r/button.json",
-        "https://originui.com/r/tooltip.json"
-      ],
       "files": [
         {
           "path": "registry/default/components/comp-359.tsx",
@@ -6580,10 +5302,6 @@
     {
       "name": "comp-360",
       "type": "registry:component",
-      "registryDependencies": [
-        "https://originui.com/r/button.json",
-        "https://originui.com/r/tooltip.json"
-      ],
       "files": [
         {
           "path": "registry/default/components/comp-360.tsx",
@@ -6598,10 +5316,6 @@
     {
       "name": "comp-361",
       "type": "registry:component",
-      "registryDependencies": [
-        "https://originui.com/r/button.json",
-        "https://originui.com/r/tooltip.json"
-      ],
       "files": [
         {
           "path": "registry/default/components/comp-361.tsx",
@@ -6616,10 +5330,6 @@
     {
       "name": "comp-362",
       "type": "registry:component",
-      "registryDependencies": [
-        "https://originui.com/r/button.json",
-        "https://originui.com/r/tooltip.json"
-      ],
       "files": [
         {
           "path": "registry/default/components/comp-362.tsx",
@@ -6634,10 +5344,6 @@
     {
       "name": "comp-363",
       "type": "registry:component",
-      "registryDependencies": [
-        "https://originui.com/r/button.json",
-        "https://originui.com/r/hover-card.json"
-      ],
       "files": [
         {
           "path": "registry/default/components/comp-363.tsx",
@@ -6652,7 +5358,6 @@
     {
       "name": "comp-364",
       "type": "registry:component",
-      "registryDependencies": ["https://originui.com/r/hover-card.json"],
       "files": [
         {
           "path": "registry/default/components/comp-364.tsx",
@@ -6667,7 +5372,6 @@
     {
       "name": "comp-365",
       "type": "registry:component",
-      "registryDependencies": ["https://originui.com/r/hover-card.json"],
       "files": [
         {
           "path": "registry/default/components/comp-365.tsx",
@@ -6682,10 +5386,6 @@
     {
       "name": "comp-366",
       "type": "registry:component",
-      "registryDependencies": [
-        "https://originui.com/r/button.json",
-        "https://originui.com/r/dropdown-menu.json"
-      ],
       "files": [
         {
           "path": "registry/default/components/comp-366.tsx",
@@ -6700,10 +5400,6 @@
     {
       "name": "comp-367",
       "type": "registry:component",
-      "registryDependencies": [
-        "https://originui.com/r/button.json",
-        "https://originui.com/r/dropdown-menu.json"
-      ],
       "files": [
         {
           "path": "registry/default/components/comp-367.tsx",
@@ -6718,10 +5414,6 @@
     {
       "name": "comp-368",
       "type": "registry:component",
-      "registryDependencies": [
-        "https://originui.com/r/button.json",
-        "https://originui.com/r/dropdown-menu.json"
-      ],
       "files": [
         {
           "path": "registry/default/components/comp-368.tsx",
@@ -6736,10 +5428,6 @@
     {
       "name": "comp-369",
       "type": "registry:component",
-      "registryDependencies": [
-        "https://originui.com/r/button.json",
-        "https://originui.com/r/dropdown-menu.json"
-      ],
       "files": [
         {
           "path": "registry/default/components/comp-369.tsx",
@@ -6754,10 +5442,6 @@
     {
       "name": "comp-370",
       "type": "registry:component",
-      "registryDependencies": [
-        "https://originui.com/r/button.json",
-        "https://originui.com/r/dropdown-menu.json"
-      ],
       "files": [
         {
           "path": "registry/default/components/comp-370.tsx",
@@ -6772,10 +5456,6 @@
     {
       "name": "comp-371",
       "type": "registry:component",
-      "registryDependencies": [
-        "https://originui.com/r/button.json",
-        "https://originui.com/r/dropdown-menu.json"
-      ],
       "files": [
         {
           "path": "registry/default/components/comp-371.tsx",
@@ -6790,10 +5470,6 @@
     {
       "name": "comp-372",
       "type": "registry:component",
-      "registryDependencies": [
-        "https://originui.com/r/button.json",
-        "https://originui.com/r/dropdown-menu.json"
-      ],
       "files": [
         {
           "path": "registry/default/components/comp-372.tsx",
@@ -6808,10 +5484,6 @@
     {
       "name": "comp-373",
       "type": "registry:component",
-      "registryDependencies": [
-        "https://originui.com/r/button.json",
-        "https://originui.com/r/dropdown-menu.json"
-      ],
       "files": [
         {
           "path": "registry/default/components/comp-373.tsx",
@@ -6826,10 +5498,6 @@
     {
       "name": "comp-374",
       "type": "registry:component",
-      "registryDependencies": [
-        "https://originui.com/r/button.json",
-        "https://originui.com/r/dropdown-menu.json"
-      ],
       "files": [
         {
           "path": "registry/default/components/comp-374.tsx",
@@ -6844,10 +5512,6 @@
     {
       "name": "comp-375",
       "type": "registry:component",
-      "registryDependencies": [
-        "https://originui.com/r/button.json",
-        "https://originui.com/r/dropdown-menu.json"
-      ],
       "files": [
         {
           "path": "registry/default/components/comp-375.tsx",
@@ -6862,10 +5526,6 @@
     {
       "name": "comp-376",
       "type": "registry:component",
-      "registryDependencies": [
-        "https://originui.com/r/button.json",
-        "https://originui.com/r/dropdown-menu.json"
-      ],
       "files": [
         {
           "path": "registry/default/components/comp-376.tsx",
@@ -6880,11 +5540,6 @@
     {
       "name": "comp-377",
       "type": "registry:component",
-      "registryDependencies": [
-        "https://originui.com/r/button.json",
-        "https://originui.com/r/dropdown-menu.json",
-        "https://originui.com/r/avatar.json"
-      ],
       "files": [
         {
           "path": "registry/default/components/comp-377.tsx",
@@ -6899,10 +5554,6 @@
     {
       "name": "comp-378",
       "type": "registry:component",
-      "registryDependencies": [
-        "https://originui.com/r/button.json",
-        "https://originui.com/r/dropdown-menu.json"
-      ],
       "files": [
         {
           "path": "registry/default/components/comp-378.tsx",
@@ -6917,10 +5568,6 @@
     {
       "name": "comp-379",
       "type": "registry:component",
-      "registryDependencies": [
-        "https://originui.com/r/button.json",
-        "https://originui.com/r/dropdown-menu.json"
-      ],
       "files": [
         {
           "path": "registry/default/components/comp-379.tsx",
@@ -6935,10 +5582,6 @@
     {
       "name": "comp-380",
       "type": "registry:component",
-      "registryDependencies": [
-        "https://originui.com/r/button.json",
-        "https://originui.com/r/dropdown-menu.json"
-      ],
       "files": [
         {
           "path": "registry/default/components/comp-380.tsx",
@@ -6953,12 +5596,6 @@
     {
       "name": "comp-381",
       "type": "registry:component",
-      "registryDependencies": [
-        "https://originui.com/r/button.json",
-        "https://originui.com/r/checkbox.json",
-        "https://originui.com/r/label.json",
-        "https://originui.com/r/popover.json"
-      ],
       "files": [
         {
           "path": "registry/default/components/comp-381.tsx",
@@ -6973,11 +5610,6 @@
     {
       "name": "comp-382",
       "type": "registry:component",
-      "registryDependencies": [
-        "https://originui.com/r/badge.json",
-        "https://originui.com/r/button.json",
-        "https://originui.com/r/popover.json"
-      ],
       "files": [
         {
           "path": "registry/default/components/comp-382.tsx",
@@ -6992,11 +5624,6 @@
     {
       "name": "comp-383",
       "type": "registry:component",
-      "registryDependencies": [
-        "https://originui.com/r/badge.json",
-        "https://originui.com/r/button.json",
-        "https://originui.com/r/popover.json"
-      ],
       "files": [
         {
           "path": "registry/default/components/comp-383.tsx",
@@ -7011,10 +5638,6 @@
     {
       "name": "comp-384",
       "type": "registry:component",
-      "registryDependencies": [
-        "https://originui.com/r/button.json",
-        "https://originui.com/r/popover.json"
-      ],
       "files": [
         {
           "path": "registry/default/components/comp-384.tsx",
@@ -7029,10 +5652,6 @@
     {
       "name": "comp-385",
       "type": "registry:component",
-      "registryDependencies": [
-        "https://originui.com/r/button.json",
-        "https://originui.com/r/popover.json"
-      ],
       "files": [
         {
           "path": "registry/default/components/comp-385.tsx",
@@ -7047,10 +5666,6 @@
     {
       "name": "comp-386",
       "type": "registry:component",
-      "registryDependencies": [
-        "https://originui.com/r/button.json",
-        "https://originui.com/r/popover.json"
-      ],
       "files": [
         {
           "path": "registry/default/components/comp-386.tsx",
@@ -7065,12 +5680,6 @@
     {
       "name": "comp-387",
       "type": "registry:component",
-      "registryDependencies": [
-        "https://originui.com/r/button.json",
-        "https://originui.com/r/input.json",
-        "https://originui.com/r/popover.json",
-        "https://originui.com/r/tooltip.json"
-      ],
       "files": [
         {
           "path": "registry/default/components/comp-387.tsx",
@@ -7085,11 +5694,6 @@
     {
       "name": "comp-388",
       "type": "registry:component",
-      "registryDependencies": [
-        "https://originui.com/r/button.json",
-        "https://originui.com/r/popover.json",
-        "https://originui.com/r/textarea.json"
-      ],
       "files": [
         {
           "path": "registry/default/components/comp-388.tsx",
@@ -7104,10 +5708,6 @@
     {
       "name": "comp-389",
       "type": "registry:component",
-      "registryDependencies": [
-        "https://originui.com/r/button.json",
-        "https://originui.com/r/popover.json"
-      ],
       "files": [
         {
           "path": "registry/default/components/comp-389.tsx",
@@ -7122,7 +5722,6 @@
     {
       "name": "comp-390",
       "type": "registry:component",
-      "registryDependencies": ["https://originui.com/r/avatar.json"],
       "files": [
         {
           "path": "registry/default/components/comp-390.tsx",
@@ -7137,7 +5736,6 @@
     {
       "name": "comp-391",
       "type": "registry:component",
-      "registryDependencies": ["https://originui.com/r/avatar.json"],
       "files": [
         {
           "path": "registry/default/components/comp-391.tsx",
@@ -7152,7 +5750,6 @@
     {
       "name": "comp-392",
       "type": "registry:component",
-      "registryDependencies": ["https://originui.com/r/avatar.json"],
       "files": [
         {
           "path": "registry/default/components/comp-392.tsx",
@@ -7167,7 +5764,6 @@
     {
       "name": "comp-393",
       "type": "registry:component",
-      "registryDependencies": ["https://originui.com/r/avatar.json"],
       "files": [
         {
           "path": "registry/default/components/comp-393.tsx",
@@ -7182,7 +5778,6 @@
     {
       "name": "comp-394",
       "type": "registry:component",
-      "registryDependencies": ["https://originui.com/r/avatar.json"],
       "files": [
         {
           "path": "registry/default/components/comp-394.tsx",
@@ -7197,7 +5792,6 @@
     {
       "name": "comp-395",
       "type": "registry:component",
-      "registryDependencies": ["https://originui.com/r/avatar.json"],
       "files": [
         {
           "path": "registry/default/components/comp-395.tsx",
@@ -7212,7 +5806,6 @@
     {
       "name": "comp-396",
       "type": "registry:component",
-      "registryDependencies": ["https://originui.com/r/avatar.json"],
       "files": [
         {
           "path": "registry/default/components/comp-396.tsx",
@@ -7227,7 +5820,6 @@
     {
       "name": "comp-397",
       "type": "registry:component",
-      "registryDependencies": ["https://originui.com/r/avatar.json"],
       "files": [
         {
           "path": "registry/default/components/comp-397.tsx",
@@ -7242,10 +5834,6 @@
     {
       "name": "comp-398",
       "type": "registry:component",
-      "registryDependencies": [
-        "https://originui.com/r/avatar.json",
-        "https://originui.com/r/badge.json"
-      ],
       "files": [
         {
           "path": "registry/default/components/comp-398.tsx",
@@ -7260,10 +5848,6 @@
     {
       "name": "comp-399",
       "type": "registry:component",
-      "registryDependencies": [
-        "https://originui.com/r/avatar.json",
-        "https://originui.com/r/badge.json"
-      ],
       "files": [
         {
           "path": "registry/default/components/comp-399.tsx",
@@ -7404,7 +5988,6 @@
     {
       "name": "comp-409",
       "type": "registry:component",
-      "registryDependencies": ["https://originui.com/r/button.json"],
       "files": [
         {
           "path": "registry/default/components/comp-409.tsx",
@@ -7419,7 +6002,6 @@
     {
       "name": "comp-410",
       "type": "registry:component",
-      "registryDependencies": ["https://originui.com/r/button.json"],
       "files": [
         {
           "path": "registry/default/components/comp-410.tsx",
@@ -7434,7 +6016,6 @@
     {
       "name": "comp-411",
       "type": "registry:component",
-      "registryDependencies": ["https://originui.com/r/button.json"],
       "files": [
         {
           "path": "registry/default/components/comp-411.tsx",
@@ -7463,7 +6044,6 @@
     {
       "name": "comp-413",
       "type": "registry:component",
-      "registryDependencies": ["https://originui.com/r/badge.json"],
       "files": [
         {
           "path": "registry/default/components/comp-413.tsx",
@@ -7478,7 +6058,6 @@
     {
       "name": "comp-414",
       "type": "registry:component",
-      "registryDependencies": ["https://originui.com/r/badge.json"],
       "files": [
         {
           "path": "registry/default/components/comp-414.tsx",
@@ -7493,7 +6072,6 @@
     {
       "name": "comp-415",
       "type": "registry:component",
-      "registryDependencies": ["https://originui.com/r/badge.json"],
       "files": [
         {
           "path": "registry/default/components/comp-415.tsx",
@@ -7508,7 +6086,6 @@
     {
       "name": "comp-416",
       "type": "registry:component",
-      "registryDependencies": ["https://originui.com/r/badge.json"],
       "files": [
         {
           "path": "registry/default/components/comp-416.tsx",
@@ -7523,7 +6100,6 @@
     {
       "name": "comp-417",
       "type": "registry:component",
-      "registryDependencies": ["https://originui.com/r/badge.json"],
       "files": [
         {
           "path": "registry/default/components/comp-417.tsx",
@@ -7538,7 +6114,6 @@
     {
       "name": "comp-418",
       "type": "registry:component",
-      "registryDependencies": ["https://originui.com/r/badge.json"],
       "files": [
         {
           "path": "registry/default/components/comp-418.tsx",
@@ -7553,7 +6128,6 @@
     {
       "name": "comp-419",
       "type": "registry:component",
-      "registryDependencies": ["https://originui.com/r/badge.json"],
       "files": [
         {
           "path": "registry/default/components/comp-419.tsx",
@@ -7568,7 +6142,6 @@
     {
       "name": "comp-420",
       "type": "registry:component",
-      "registryDependencies": ["https://originui.com/r/badge.json"],
       "files": [
         {
           "path": "registry/default/components/comp-420.tsx",
@@ -7583,7 +6156,6 @@
     {
       "name": "comp-421",
       "type": "registry:component",
-      "registryDependencies": ["https://originui.com/r/badge.json"],
       "files": [
         {
           "path": "registry/default/components/comp-421.tsx",
@@ -7598,7 +6170,6 @@
     {
       "name": "comp-422",
       "type": "registry:component",
-      "registryDependencies": ["https://originui.com/r/badge.json"],
       "files": [
         {
           "path": "registry/default/components/comp-422.tsx",
@@ -7613,7 +6184,6 @@
     {
       "name": "comp-423",
       "type": "registry:component",
-      "registryDependencies": ["https://originui.com/r/badge.json"],
       "files": [
         {
           "path": "registry/default/components/comp-423.tsx",
@@ -7642,7 +6212,6 @@
     {
       "name": "comp-425",
       "type": "registry:component",
-      "registryDependencies": ["https://originui.com/r/badge.json"],
       "files": [
         {
           "path": "registry/default/components/comp-425.tsx",
@@ -7657,7 +6226,6 @@
     {
       "name": "comp-426",
       "type": "registry:component",
-      "registryDependencies": ["https://originui.com/r/tabs.json"],
       "files": [
         {
           "path": "registry/default/components/comp-426.tsx",
@@ -7673,7 +6241,6 @@
     {
       "name": "comp-427",
       "type": "registry:component",
-      "registryDependencies": ["https://originui.com/r/tabs.json"],
       "files": [
         {
           "path": "registry/default/components/comp-427.tsx",
@@ -7689,7 +6256,6 @@
     {
       "name": "comp-428",
       "type": "registry:component",
-      "registryDependencies": ["https://originui.com/r/tabs.json"],
       "files": [
         {
           "path": "registry/default/components/comp-428.tsx",
@@ -7705,7 +6271,6 @@
     {
       "name": "comp-429",
       "type": "registry:component",
-      "registryDependencies": ["https://originui.com/r/tabs.json"],
       "files": [
         {
           "path": "registry/default/components/comp-429.tsx",
@@ -7721,7 +6286,6 @@
     {
       "name": "comp-430",
       "type": "registry:component",
-      "registryDependencies": ["https://originui.com/r/tabs.json"],
       "files": [
         {
           "path": "registry/default/components/comp-430.tsx",
@@ -7737,7 +6301,6 @@
     {
       "name": "comp-431",
       "type": "registry:component",
-      "registryDependencies": ["https://originui.com/r/tabs.json"],
       "files": [
         {
           "path": "registry/default/components/comp-431.tsx",
@@ -7753,7 +6316,6 @@
     {
       "name": "comp-432",
       "type": "registry:component",
-      "registryDependencies": ["https://originui.com/r/tabs.json"],
       "files": [
         {
           "path": "registry/default/components/comp-432.tsx",
@@ -7769,10 +6331,6 @@
     {
       "name": "comp-433",
       "type": "registry:component",
-      "registryDependencies": [
-        "https://originui.com/r/scroll-area.json",
-        "https://originui.com/r/tabs.json"
-      ],
       "files": [
         {
           "path": "registry/default/components/comp-433.tsx",
@@ -7788,10 +6346,6 @@
     {
       "name": "comp-434",
       "type": "registry:component",
-      "registryDependencies": [
-        "https://originui.com/r/scroll-area.json",
-        "https://originui.com/r/tabs.json"
-      ],
       "files": [
         {
           "path": "registry/default/components/comp-434.tsx",
@@ -7807,10 +6361,6 @@
     {
       "name": "comp-435",
       "type": "registry:component",
-      "registryDependencies": [
-        "https://originui.com/r/scroll-area.json",
-        "https://originui.com/r/tabs.json"
-      ],
       "files": [
         {
           "path": "registry/default/components/comp-435.tsx",
@@ -7826,10 +6376,6 @@
     {
       "name": "comp-436",
       "type": "registry:component",
-      "registryDependencies": [
-        "https://originui.com/r/scroll-area.json",
-        "https://originui.com/r/tabs.json"
-      ],
       "files": [
         {
           "path": "registry/default/components/comp-436.tsx",
@@ -7845,11 +6391,6 @@
     {
       "name": "comp-437",
       "type": "registry:component",
-      "registryDependencies": [
-        "https://originui.com/r/badge.json",
-        "https://originui.com/r/scroll-area.json",
-        "https://originui.com/r/tabs.json"
-      ],
       "files": [
         {
           "path": "registry/default/components/comp-437.tsx",
@@ -7865,7 +6406,6 @@
     {
       "name": "comp-438",
       "type": "registry:component",
-      "registryDependencies": ["https://originui.com/r/tabs.json"],
       "files": [
         {
           "path": "registry/default/components/comp-438.tsx",
@@ -7881,7 +6421,6 @@
     {
       "name": "comp-439",
       "type": "registry:component",
-      "registryDependencies": ["https://originui.com/r/tabs.json"],
       "files": [
         {
           "path": "registry/default/components/comp-439.tsx",
@@ -7897,10 +6436,6 @@
     {
       "name": "comp-440",
       "type": "registry:component",
-      "registryDependencies": [
-        "https://originui.com/r/tabs.json",
-        "https://originui.com/r/tooltip.json"
-      ],
       "files": [
         {
           "path": "registry/default/components/comp-440.tsx",
@@ -7916,10 +6451,6 @@
     {
       "name": "comp-441",
       "type": "registry:component",
-      "registryDependencies": [
-        "https://originui.com/r/tabs.json",
-        "https://originui.com/r/tooltip.json"
-      ],
       "files": [
         {
           "path": "registry/default/components/comp-441.tsx",
@@ -7935,7 +6466,6 @@
     {
       "name": "comp-442",
       "type": "registry:component",
-      "registryDependencies": ["https://originui.com/r/tabs.json"],
       "files": [
         {
           "path": "registry/default/components/comp-442.tsx",
@@ -7951,7 +6481,6 @@
     {
       "name": "comp-443",
       "type": "registry:component",
-      "registryDependencies": ["https://originui.com/r/tabs.json"],
       "files": [
         {
           "path": "registry/default/components/comp-443.tsx",
@@ -7967,7 +6496,6 @@
     {
       "name": "comp-444",
       "type": "registry:component",
-      "registryDependencies": ["https://originui.com/r/tabs.json"],
       "files": [
         {
           "path": "registry/default/components/comp-444.tsx",
@@ -7983,7 +6511,6 @@
     {
       "name": "comp-445",
       "type": "registry:component",
-      "registryDependencies": ["https://originui.com/r/tabs.json"],
       "files": [
         {
           "path": "registry/default/components/comp-445.tsx",
@@ -7999,10 +6526,6 @@
     {
       "name": "comp-446",
       "type": "registry:component",
-      "registryDependencies": [
-        "https://originui.com/r/breadcrumb.json",
-        "https://originui.com/r/dropdown-menu.json"
-      ],
       "files": [
         {
           "path": "registry/default/components/comp-446.tsx",
@@ -8018,10 +6541,6 @@
     {
       "name": "comp-447",
       "type": "registry:component",
-      "registryDependencies": [
-        "https://originui.com/r/breadcrumb.json",
-        "https://originui.com/r/dropdown-menu.json"
-      ],
       "files": [
         {
           "path": "registry/default/components/comp-447.tsx",
@@ -8037,7 +6556,6 @@
     {
       "name": "comp-448",
       "type": "registry:component",
-      "registryDependencies": ["https://originui.com/r/breadcrumb.json"],
       "files": [
         {
           "path": "registry/default/components/comp-448.tsx",
@@ -8053,7 +6571,6 @@
     {
       "name": "comp-449",
       "type": "registry:component",
-      "registryDependencies": ["https://originui.com/r/breadcrumb.json"],
       "files": [
         {
           "path": "registry/default/components/comp-449.tsx",
@@ -8069,7 +6586,6 @@
     {
       "name": "comp-450",
       "type": "registry:component",
-      "registryDependencies": ["https://originui.com/r/breadcrumb.json"],
       "files": [
         {
           "path": "registry/default/components/comp-450.tsx",
@@ -8085,7 +6601,6 @@
     {
       "name": "comp-451",
       "type": "registry:component",
-      "registryDependencies": ["https://originui.com/r/breadcrumb.json"],
       "files": [
         {
           "path": "registry/default/components/comp-451.tsx",
@@ -8101,7 +6616,6 @@
     {
       "name": "comp-452",
       "type": "registry:component",
-      "registryDependencies": ["https://originui.com/r/breadcrumb.json"],
       "files": [
         {
           "path": "registry/default/components/comp-452.tsx",
@@ -8117,10 +6631,6 @@
     {
       "name": "comp-453",
       "type": "registry:component",
-      "registryDependencies": [
-        "https://originui.com/r/breadcrumb.json",
-        "https://originui.com/r/select.json"
-      ],
       "files": [
         {
           "path": "registry/default/components/comp-453.tsx",
@@ -8136,10 +6646,6 @@
     {
       "name": "comp-454",
       "type": "registry:component",
-      "registryDependencies": [
-        "https://originui.com/r/button.json",
-        "https://originui.com/r/pagination.json"
-      ],
       "files": [
         {
           "path": "registry/default/components/comp-454.tsx",
@@ -8154,10 +6660,6 @@
     {
       "name": "comp-455",
       "type": "registry:component",
-      "registryDependencies": [
-        "https://originui.com/r/button.json",
-        "https://originui.com/r/pagination.json"
-      ],
       "files": [
         {
           "path": "registry/default/components/comp-455.tsx",
@@ -8172,10 +6674,6 @@
     {
       "name": "comp-456",
       "type": "registry:component",
-      "registryDependencies": [
-        "https://originui.com/r/button.json",
-        "https://originui.com/r/pagination.json"
-      ],
       "files": [
         {
           "path": "registry/default/components/comp-456.tsx",
@@ -8190,7 +6688,6 @@
     {
       "name": "comp-457",
       "type": "registry:component",
-      "registryDependencies": ["https://originui.com/r/pagination.json"],
       "files": [
         {
           "path": "registry/default/components/comp-457.tsx",
@@ -8205,10 +6702,6 @@
     {
       "name": "comp-458",
       "type": "registry:component",
-      "registryDependencies": [
-        "https://originui.com/r/button.json",
-        "https://originui.com/r/pagination.json"
-      ],
       "files": [
         {
           "path": "registry/default/components/comp-458.tsx",
@@ -8223,15 +6716,10 @@
     {
       "name": "comp-459",
       "type": "registry:component",
-      "registryDependencies": ["https://originui.com/r/pagination.json"],
       "files": [
         {
           "path": "registry/default/components/comp-459.tsx",
           "type": "registry:component"
-        },
-        {
-          "path": "registry/default/hooks/use-pagination.ts",
-          "type": "registry:hook"
         }
       ],
       "meta": {
@@ -8242,15 +6730,10 @@
     {
       "name": "comp-460",
       "type": "registry:component",
-      "registryDependencies": ["https://originui.com/r/pagination.json"],
       "files": [
         {
           "path": "registry/default/components/comp-460.tsx",
           "type": "registry:component"
-        },
-        {
-          "path": "registry/default/hooks/use-pagination.ts",
-          "type": "registry:hook"
         }
       ],
       "meta": {
@@ -8261,18 +6744,10 @@
     {
       "name": "comp-461",
       "type": "registry:component",
-      "registryDependencies": [
-        "https://originui.com/r/button.json",
-        "https://originui.com/r/pagination.json"
-      ],
       "files": [
         {
           "path": "registry/default/components/comp-461.tsx",
           "type": "registry:component"
-        },
-        {
-          "path": "registry/default/hooks/use-pagination.ts",
-          "type": "registry:hook"
         }
       ],
       "meta": {
@@ -8283,18 +6758,10 @@
     {
       "name": "comp-462",
       "type": "registry:component",
-      "registryDependencies": [
-        "https://originui.com/r/pagination.json",
-        "https://originui.com/r/select.json"
-      ],
       "files": [
         {
           "path": "registry/default/components/comp-462.tsx",
           "type": "registry:component"
-        },
-        {
-          "path": "registry/default/hooks/use-pagination.ts",
-          "type": "registry:hook"
         }
       ],
       "meta": {
@@ -8305,19 +6772,10 @@
     {
       "name": "comp-463",
       "type": "registry:component",
-      "registryDependencies": [
-        "https://originui.com/r/label.json",
-        "https://originui.com/r/pagination.json",
-        "https://originui.com/r/select.json"
-      ],
       "files": [
         {
           "path": "registry/default/components/comp-463.tsx",
           "type": "registry:component"
-        },
-        {
-          "path": "registry/default/hooks/use-pagination.ts",
-          "type": "registry:hook"
         }
       ],
       "meta": {
@@ -8328,18 +6786,10 @@
     {
       "name": "comp-464",
       "type": "registry:component",
-      "registryDependencies": [
-        "https://originui.com/r/pagination.json",
-        "https://originui.com/r/select.json"
-      ],
       "files": [
         {
           "path": "registry/default/components/comp-464.tsx",
           "type": "registry:component"
-        },
-        {
-          "path": "registry/default/hooks/use-pagination.ts",
-          "type": "registry:hook"
         }
       ],
       "meta": {
@@ -8350,19 +6800,10 @@
     {
       "name": "comp-465",
       "type": "registry:component",
-      "registryDependencies": [
-        "https://originui.com/r/input.json",
-        "https://originui.com/r/label.json",
-        "https://originui.com/r/pagination.json"
-      ],
       "files": [
         {
           "path": "registry/default/components/comp-465.tsx",
           "type": "registry:component"
-        },
-        {
-          "path": "registry/default/hooks/use-pagination.ts",
-          "type": "registry:hook"
         }
       ],
       "meta": {
@@ -8373,7 +6814,6 @@
     {
       "name": "comp-466",
       "type": "registry:component",
-      "registryDependencies": ["https://originui.com/r/table.json"],
       "files": [
         {
           "path": "registry/default/components/comp-466.tsx",
@@ -8388,7 +6828,6 @@
     {
       "name": "comp-467",
       "type": "registry:component",
-      "registryDependencies": ["https://originui.com/r/table.json"],
       "files": [
         {
           "path": "registry/default/components/comp-467.tsx",
@@ -8403,7 +6842,6 @@
     {
       "name": "comp-468",
       "type": "registry:component",
-      "registryDependencies": ["https://originui.com/r/table.json"],
       "files": [
         {
           "path": "registry/default/components/comp-468.tsx",
@@ -8418,7 +6856,6 @@
     {
       "name": "comp-469",
       "type": "registry:component",
-      "registryDependencies": ["https://originui.com/r/table.json"],
       "files": [
         {
           "path": "registry/default/components/comp-469.tsx",
@@ -8433,7 +6870,6 @@
     {
       "name": "comp-470",
       "type": "registry:component",
-      "registryDependencies": ["https://originui.com/r/table.json"],
       "files": [
         {
           "path": "registry/default/components/comp-470.tsx",
@@ -8448,7 +6884,6 @@
     {
       "name": "comp-471",
       "type": "registry:component",
-      "registryDependencies": ["https://originui.com/r/table.json"],
       "files": [
         {
           "path": "registry/default/components/comp-471.tsx",
@@ -8463,10 +6898,6 @@
     {
       "name": "comp-472",
       "type": "registry:component",
-      "registryDependencies": [
-        "https://originui.com/r/checkbox.json",
-        "https://originui.com/r/table.json"
-      ],
       "files": [
         {
           "path": "registry/default/components/comp-472.tsx",
@@ -8481,10 +6912,6 @@
     {
       "name": "comp-473",
       "type": "registry:component",
-      "registryDependencies": [
-        "https://originui.com/r/checkbox.json",
-        "https://originui.com/r/table.json"
-      ],
       "files": [
         {
           "path": "registry/default/components/comp-473.tsx",
@@ -8499,7 +6926,6 @@
     {
       "name": "comp-474",
       "type": "registry:component",
-      "registryDependencies": ["https://originui.com/r/table.json"],
       "files": [
         {
           "path": "registry/default/components/comp-474.tsx",
@@ -8514,7 +6940,6 @@
     {
       "name": "comp-475",
       "type": "registry:component",
-      "registryDependencies": ["https://originui.com/r/table.json"],
       "files": [
         {
           "path": "registry/default/components/comp-475.tsx",
@@ -8529,7 +6954,6 @@
     {
       "name": "comp-476",
       "type": "registry:component",
-      "registryDependencies": ["https://originui.com/r/table.json"],
       "files": [
         {
           "path": "registry/default/components/comp-476.tsx",
@@ -8544,12 +6968,6 @@
     {
       "name": "comp-477",
       "type": "registry:component",
-      "registryDependencies": [
-        "https://originui.com/r/badge.json",
-        "https://originui.com/r/checkbox.json",
-        "https://originui.com/r/table.json"
-      ],
-      "dependencies": ["@tanstack/react-table"],
       "files": [
         {
           "path": "registry/default/components/comp-477.tsx",
@@ -8564,14 +6982,6 @@
     {
       "name": "comp-478",
       "type": "registry:component",
-      "registryDependencies": [
-        "https://originui.com/r/checkbox.json",
-        "https://originui.com/r/input.json",
-        "https://originui.com/r/label.json",
-        "https://originui.com/r/select.json",
-        "https://originui.com/r/table.json"
-      ],
-      "dependencies": ["@tanstack/react-table"],
       "files": [
         {
           "path": "registry/default/components/comp-478.tsx",
@@ -8579,25 +6989,13 @@
         }
       ],
       "meta": {
-        "tags": [
-          "table",
-          "tanstack",
-          "checkbox",
-          "search",
-          "select",
-          "range",
-          "input",
-          "filter",
-          "sort"
-        ],
+        "tags": ["table", "tanstack", "checkbox", "search", "select", "range", "input", "filter", "sort"],
         "colSpan": 3
       }
     },
     {
       "name": "comp-479",
       "type": "registry:component",
-      "registryDependencies": ["https://originui.com/r/table.json"],
-      "dependencies": ["@tanstack/react-table"],
       "files": [
         {
           "path": "registry/default/components/comp-479.tsx",
@@ -8612,12 +7010,6 @@
     {
       "name": "comp-480",
       "type": "registry:component",
-      "registryDependencies": [
-        "https://originui.com/r/button.json",
-        "https://originui.com/r/dropdown-menu.json",
-        "https://originui.com/r/table.json"
-      ],
-      "dependencies": ["@tanstack/react-table"],
       "files": [
         {
           "path": "registry/default/components/comp-480.tsx",
@@ -8632,18 +7024,6 @@
     {
       "name": "comp-481",
       "type": "registry:component",
-      "registryDependencies": [
-        "https://originui.com/r/button.json",
-        "https://originui.com/r/dropdown-menu.json",
-        "https://originui.com/r/table.json"
-      ],
-      "dependencies": [
-        "@dnd-kit/core",
-        "@dnd-kit/modifiers",
-        "@dnd-kit/sortable",
-        "@dnd-kit/utilities",
-        "@tanstack/react-table"
-      ],
       "files": [
         {
           "path": "registry/default/components/comp-481.tsx",
@@ -8658,13 +7038,6 @@
     {
       "name": "comp-482",
       "type": "registry:component",
-      "registryDependencies": [
-        "https://originui.com/r/badge.json",
-        "https://originui.com/r/button.json",
-        "https://originui.com/r/checkbox.json",
-        "https://originui.com/r/table.json"
-      ],
-      "dependencies": ["@tanstack/react-table"],
       "files": [
         {
           "path": "registry/default/components/comp-482.tsx",
@@ -8679,16 +7052,6 @@
     {
       "name": "comp-483",
       "type": "registry:component",
-      "registryDependencies": [
-        "https://originui.com/r/badge.json",
-        "https://originui.com/r/button.json",
-        "https://originui.com/r/checkbox.json",
-        "https://originui.com/r/label.json",
-        "https://originui.com/r/pagination.json",
-        "https://originui.com/r/select.json",
-        "https://originui.com/r/table.json"
-      ],
-      "dependencies": ["@tanstack/react-table"],
       "files": [
         {
           "path": "registry/default/components/comp-483.tsx",
@@ -8703,23 +7066,10 @@
     {
       "name": "comp-484",
       "type": "registry:component",
-      "registryDependencies": [
-        "https://originui.com/r/badge.json",
-        "https://originui.com/r/button.json",
-        "https://originui.com/r/checkbox.json",
-        "https://originui.com/r/pagination.json",
-        "https://originui.com/r/select.json",
-        "https://originui.com/r/table.json"
-      ],
-      "dependencies": ["@tanstack/react-table"],
       "files": [
         {
           "path": "registry/default/components/comp-484.tsx",
           "type": "registry:component"
-        },
-        {
-          "path": "registry/default/hooks/use-pagination.ts",
-          "type": "registry:hook"
         }
       ],
       "meta": {
@@ -8730,20 +7080,6 @@
     {
       "name": "comp-485",
       "type": "registry:component",
-      "registryDependencies": [
-        "https://originui.com/r/alert-dialog.json",
-        "https://originui.com/r/badge.json",
-        "https://originui.com/r/button.json",
-        "https://originui.com/r/checkbox.json",
-        "https://originui.com/r/dropdown-menu.json",
-        "https://originui.com/r/input.json",
-        "https://originui.com/r/label.json",
-        "https://originui.com/r/pagination.json",
-        "https://originui.com/r/popover.json",
-        "https://originui.com/r/select.json",
-        "https://originui.com/r/table.json"
-      ],
-      "dependencies": ["@tanstack/react-table"],
       "files": [
         {
           "path": "registry/default/components/comp-485.tsx",
@@ -8751,28 +7087,13 @@
         }
       ],
       "meta": {
-        "tags": [
-          "table",
-          "tanstack",
-          "checkbox",
-          "sort",
-          "flag",
-          "badge",
-          "chip",
-          "pagination",
-          "filter",
-          "select"
-        ],
+        "tags": ["table", "tanstack", "checkbox", "sort", "flag", "badge", "chip", "pagination", "filter", "select"],
         "colSpan": 3
       }
     },
     {
       "name": "comp-486",
       "type": "registry:component",
-      "registryDependencies": [
-        "https://originui.com/r/input.json",
-        "https://originui.com/r/label.json"
-      ],
       "files": [
         {
           "path": "registry/default/components/comp-486.tsx",
@@ -8786,8 +7107,6 @@
     {
       "name": "comp-487",
       "type": "registry:component",
-      "registryDependencies": ["https://originui.com/r/calendar-rac.json"],
-      "dependencies": ["react-aria-components"],
       "files": [
         {
           "path": "registry/default/components/comp-487.tsx",
@@ -8802,8 +7121,6 @@
     {
       "name": "comp-488",
       "type": "registry:component",
-      "registryDependencies": ["https://originui.com/r/calendar-rac.json"],
-      "dependencies": ["react-aria-components"],
       "files": [
         {
           "path": "registry/default/components/comp-488.tsx",
@@ -8818,8 +7135,6 @@
     {
       "name": "comp-489",
       "type": "registry:component",
-      "registryDependencies": ["https://originui.com/r/calendar-rac.json"],
-      "dependencies": ["react-aria-components"],
       "files": [
         {
           "path": "registry/default/components/comp-489.tsx",
@@ -8834,7 +7149,6 @@
     {
       "name": "comp-490",
       "type": "registry:component",
-      "registryDependencies": ["https://originui.com/r/calendar.json"],
       "files": [
         {
           "path": "registry/default/components/comp-490.tsx",
@@ -8849,7 +7163,6 @@
     {
       "name": "comp-491",
       "type": "registry:component",
-      "registryDependencies": ["https://originui.com/r/calendar.json"],
       "files": [
         {
           "path": "registry/default/components/comp-491.tsx",
@@ -8864,7 +7177,6 @@
     {
       "name": "comp-492",
       "type": "registry:component",
-      "registryDependencies": ["https://originui.com/r/calendar.json"],
       "files": [
         {
           "path": "registry/default/components/comp-492.tsx",
@@ -8879,7 +7191,6 @@
     {
       "name": "comp-493",
       "type": "registry:component",
-      "registryDependencies": ["https://originui.com/r/calendar.json"],
       "files": [
         {
           "path": "registry/default/components/comp-493.tsx",
@@ -8894,7 +7205,6 @@
     {
       "name": "comp-494",
       "type": "registry:component",
-      "registryDependencies": ["https://originui.com/r/calendar.json"],
       "files": [
         {
           "path": "registry/default/components/comp-494.tsx",
@@ -8909,7 +7219,6 @@
     {
       "name": "comp-495",
       "type": "registry:component",
-      "registryDependencies": ["https://originui.com/r/calendar.json"],
       "files": [
         {
           "path": "registry/default/components/comp-495.tsx",
@@ -8924,7 +7233,6 @@
     {
       "name": "comp-496",
       "type": "registry:component",
-      "registryDependencies": ["https://originui.com/r/calendar.json"],
       "files": [
         {
           "path": "registry/default/components/comp-496.tsx",
@@ -8939,10 +7247,6 @@
     {
       "name": "comp-497",
       "type": "registry:component",
-      "registryDependencies": [
-        "https://originui.com/r/calendar.json",
-        "https://originui.com/r/select.json"
-      ],
       "files": [
         {
           "path": "registry/default/components/comp-497.tsx",
@@ -8957,10 +7261,6 @@
     {
       "name": "comp-498",
       "type": "registry:component",
-      "registryDependencies": [
-        "https://originui.com/r/calendar.json",
-        "https://originui.com/r/select.json"
-      ],
       "files": [
         {
           "path": "registry/default/components/comp-498.tsx",
@@ -8975,7 +7275,6 @@
     {
       "name": "comp-499",
       "type": "registry:component",
-      "registryDependencies": ["https://originui.com/r/calendar.json"],
       "files": [
         {
           "path": "registry/default/components/comp-499.tsx",
@@ -8990,10 +7289,6 @@
     {
       "name": "comp-500",
       "type": "registry:component",
-      "registryDependencies": [
-        "https://originui.com/r/button.json",
-        "https://originui.com/r/calendar.json"
-      ],
       "files": [
         {
           "path": "registry/default/components/comp-500.tsx",
@@ -9008,10 +7303,6 @@
     {
       "name": "comp-501",
       "type": "registry:component",
-      "registryDependencies": [
-        "https://originui.com/r/button.json",
-        "https://originui.com/r/calendar.json"
-      ],
       "files": [
         {
           "path": "registry/default/components/comp-501.tsx",
@@ -9026,11 +7317,6 @@
     {
       "name": "comp-502",
       "type": "registry:component",
-      "registryDependencies": [
-        "https://originui.com/r/calendar.json",
-        "https://originui.com/r/input.json",
-        "https://originui.com/r/label.json"
-      ],
       "files": [
         {
           "path": "registry/default/components/comp-502.tsx",
@@ -9045,11 +7331,6 @@
     {
       "name": "comp-503",
       "type": "registry:component",
-      "registryDependencies": [
-        "https://originui.com/r/calendar.json",
-        "https://originui.com/r/input.json",
-        "https://originui.com/r/label.json"
-      ],
       "files": [
         {
           "path": "registry/default/components/comp-503.tsx",
@@ -9064,12 +7345,6 @@
     {
       "name": "comp-504",
       "type": "registry:component",
-      "registryDependencies": [
-        "https://originui.com/r/button.json",
-        "https://originui.com/r/calendar.json",
-        "https://originui.com/r/collapsible.json",
-        "https://originui.com/r/scroll-area.json"
-      ],
       "files": [
         {
           "path": "registry/default/components/comp-504.tsx",
@@ -9084,11 +7359,6 @@
     {
       "name": "comp-505",
       "type": "registry:component",
-      "registryDependencies": [
-        "https://originui.com/r/button.json",
-        "https://originui.com/r/calendar.json",
-        "https://originui.com/r/scroll-area.json"
-      ],
       "files": [
         {
           "path": "registry/default/components/comp-505.tsx",
@@ -9104,10 +7374,6 @@
     {
       "name": "comp-506",
       "type": "registry:component",
-      "registryDependencies": [
-        "https://originui.com/r/button.json",
-        "https://originui.com/r/calendar.json"
-      ],
       "files": [
         {
           "path": "registry/default/components/comp-506.tsx",
@@ -9123,10 +7389,6 @@
     {
       "name": "comp-507",
       "type": "registry:component",
-      "registryDependencies": [
-        "https://originui.com/r/button.json",
-        "https://originui.com/r/calendar.json"
-      ],
       "files": [
         {
           "path": "registry/default/components/comp-507.tsx",
@@ -9142,7 +7404,6 @@
     {
       "name": "comp-508",
       "type": "registry:component",
-      "registryDependencies": ["https://originui.com/r/calendar.json"],
       "files": [
         {
           "path": "registry/default/components/comp-508.tsx",
@@ -9158,7 +7419,6 @@
     {
       "name": "comp-509",
       "type": "registry:component",
-      "registryDependencies": ["https://originui.com/r/calendar.json"],
       "files": [
         {
           "path": "registry/default/components/comp-509.tsx",
@@ -9174,7 +7434,6 @@
     {
       "name": "comp-510",
       "type": "registry:component",
-      "registryDependencies": ["https://originui.com/r/calendar.json"],
       "files": [
         {
           "path": "registry/default/components/comp-510.tsx",
@@ -9190,12 +7449,6 @@
     {
       "name": "comp-511",
       "type": "registry:component",
-      "registryDependencies": [
-        "https://originui.com/r/button.json",
-        "https://originui.com/r/calendar.json",
-        "https://originui.com/r/label.json",
-        "https://originui.com/r/popover.json"
-      ],
       "files": [
         {
           "path": "registry/default/components/comp-511.tsx",
@@ -9209,12 +7462,6 @@
     {
       "name": "comp-512",
       "type": "registry:component",
-      "registryDependencies": [
-        "https://originui.com/r/button.json",
-        "https://originui.com/r/calendar.json",
-        "https://originui.com/r/label.json",
-        "https://originui.com/r/popover.json"
-      ],
       "files": [
         {
           "path": "registry/default/components/comp-512.tsx",
@@ -9228,7 +7475,6 @@
     {
       "name": "comp-513",
       "type": "registry:component",
-      "registryDependencies": ["https://originui.com/r/stepper.json"],
       "files": [
         {
           "path": "registry/default/components/comp-513.tsx",
@@ -9243,7 +7489,6 @@
     {
       "name": "comp-514",
       "type": "registry:component",
-      "registryDependencies": ["https://originui.com/r/stepper.json"],
       "files": [
         {
           "path": "registry/default/components/comp-514.tsx",
@@ -9258,7 +7503,6 @@
     {
       "name": "comp-515",
       "type": "registry:component",
-      "registryDependencies": ["https://originui.com/r/stepper.json"],
       "files": [
         {
           "path": "registry/default/components/comp-515.tsx",
@@ -9273,7 +7517,6 @@
     {
       "name": "comp-516",
       "type": "registry:component",
-      "registryDependencies": ["https://originui.com/r/stepper.json"],
       "files": [
         {
           "path": "registry/default/components/comp-516.tsx",
@@ -9288,7 +7531,6 @@
     {
       "name": "comp-517",
       "type": "registry:component",
-      "registryDependencies": ["https://originui.com/r/stepper.json"],
       "files": [
         {
           "path": "registry/default/components/comp-517.tsx",
@@ -9303,7 +7545,6 @@
     {
       "name": "comp-518",
       "type": "registry:component",
-      "registryDependencies": ["https://originui.com/r/stepper.json"],
       "files": [
         {
           "path": "registry/default/components/comp-518.tsx",
@@ -9318,7 +7559,6 @@
     {
       "name": "comp-519",
       "type": "registry:component",
-      "registryDependencies": ["https://originui.com/r/stepper.json"],
       "files": [
         {
           "path": "registry/default/components/comp-519.tsx",
@@ -9333,7 +7573,6 @@
     {
       "name": "comp-520",
       "type": "registry:component",
-      "registryDependencies": ["https://originui.com/r/stepper.json"],
       "files": [
         {
           "path": "registry/default/components/comp-520.tsx",
@@ -9348,7 +7587,6 @@
     {
       "name": "comp-521",
       "type": "registry:component",
-      "registryDependencies": ["https://originui.com/r/stepper.json"],
       "files": [
         {
           "path": "registry/default/components/comp-521.tsx",
@@ -9363,7 +7601,6 @@
     {
       "name": "comp-522",
       "type": "registry:component",
-      "registryDependencies": ["https://originui.com/r/stepper.json"],
       "files": [
         {
           "path": "registry/default/components/comp-522.tsx",
@@ -9378,7 +7615,6 @@
     {
       "name": "comp-523",
       "type": "registry:component",
-      "registryDependencies": ["https://originui.com/r/stepper.json"],
       "files": [
         {
           "path": "registry/default/components/comp-523.tsx",
@@ -9393,7 +7629,6 @@
     {
       "name": "comp-524",
       "type": "registry:component",
-      "registryDependencies": ["https://originui.com/r/stepper.json"],
       "files": [
         {
           "path": "registry/default/components/comp-524.tsx",
@@ -9408,7 +7643,6 @@
     {
       "name": "comp-525",
       "type": "registry:component",
-      "registryDependencies": ["https://originui.com/r/stepper.json"],
       "files": [
         {
           "path": "registry/default/components/comp-525.tsx",
@@ -9423,7 +7657,6 @@
     {
       "name": "comp-526",
       "type": "registry:component",
-      "registryDependencies": ["https://originui.com/r/stepper.json"],
       "files": [
         {
           "path": "registry/default/components/comp-526.tsx",
@@ -9438,7 +7671,6 @@
     {
       "name": "comp-527",
       "type": "registry:component",
-      "registryDependencies": ["https://originui.com/r/stepper.json"],
       "files": [
         {
           "path": "registry/default/components/comp-527.tsx",
@@ -9453,7 +7685,6 @@
     {
       "name": "comp-528",
       "type": "registry:component",
-      "registryDependencies": ["https://originui.com/r/stepper.json"],
       "files": [
         {
           "path": "registry/default/components/comp-528.tsx",
@@ -9468,7 +7699,6 @@
     {
       "name": "comp-529",
       "type": "registry:component",
-      "registryDependencies": ["https://originui.com/r/stepper.json"],
       "files": [
         {
           "path": "registry/default/components/comp-529.tsx",
@@ -9483,7 +7713,6 @@
     {
       "name": "comp-530",
       "type": "registry:component",
-      "registryDependencies": ["https://originui.com/r/timeline.json"],
       "files": [
         {
           "path": "registry/default/components/comp-530.tsx",
@@ -9498,7 +7727,6 @@
     {
       "name": "comp-531",
       "type": "registry:component",
-      "registryDependencies": ["https://originui.com/r/timeline.json"],
       "files": [
         {
           "path": "registry/default/components/comp-531.tsx",
@@ -9513,7 +7741,6 @@
     {
       "name": "comp-532",
       "type": "registry:component",
-      "registryDependencies": ["https://originui.com/r/timeline.json"],
       "files": [
         {
           "path": "registry/default/components/comp-532.tsx",
@@ -9528,7 +7755,6 @@
     {
       "name": "comp-533",
       "type": "registry:component",
-      "registryDependencies": ["https://originui.com/r/timeline.json"],
       "files": [
         {
           "path": "registry/default/components/comp-533.tsx",
@@ -9543,7 +7769,6 @@
     {
       "name": "comp-534",
       "type": "registry:component",
-      "registryDependencies": ["https://originui.com/r/timeline.json"],
       "files": [
         {
           "path": "registry/default/components/comp-534.tsx",
@@ -9558,7 +7783,6 @@
     {
       "name": "comp-535",
       "type": "registry:component",
-      "registryDependencies": ["https://originui.com/r/timeline.json"],
       "files": [
         {
           "path": "registry/default/components/comp-535.tsx",
@@ -9573,7 +7797,6 @@
     {
       "name": "comp-536",
       "type": "registry:component",
-      "registryDependencies": ["https://originui.com/r/timeline.json"],
       "files": [
         {
           "path": "registry/default/components/comp-536.tsx",
@@ -9588,7 +7811,6 @@
     {
       "name": "comp-537",
       "type": "registry:component",
-      "registryDependencies": ["https://originui.com/r/timeline.json"],
       "files": [
         {
           "path": "registry/default/components/comp-537.tsx",
@@ -9603,7 +7825,6 @@
     {
       "name": "comp-538",
       "type": "registry:component",
-      "registryDependencies": ["https://originui.com/r/timeline.json"],
       "files": [
         {
           "path": "registry/default/components/comp-538.tsx",
@@ -9618,7 +7839,6 @@
     {
       "name": "comp-539",
       "type": "registry:component",
-      "registryDependencies": ["https://originui.com/r/timeline.json"],
       "files": [
         {
           "path": "registry/default/components/comp-539.tsx",
@@ -9633,7 +7853,6 @@
     {
       "name": "comp-540",
       "type": "registry:component",
-      "registryDependencies": ["https://originui.com/r/timeline.json"],
       "files": [
         {
           "path": "registry/default/components/comp-540.tsx",
@@ -9648,7 +7867,6 @@
     {
       "name": "comp-541",
       "type": "registry:component",
-      "registryDependencies": ["https://originui.com/r/timeline.json"],
       "files": [
         {
           "path": "registry/default/components/comp-541.tsx",
@@ -9663,92 +7881,9 @@
     {
       "name": "comp-542",
       "type": "registry:component",
-      "dependencies": ["date-fns", "@dnd-kit/core", "@dnd-kit/modifiers", "@dnd-kit/utilities", "@remixicon/react"],
-      "registryDependencies": [
-        "https://originui.com/r/button.json",
-        "https://originui.com/r/calendar.json",
-        "https://originui.com/r/checkbox.json",
-        "https://originui.com/r/dropdown-menu.json",
-        "https://originui.com/r/dialog.json",
-        "https://originui.com/r/input.json",
-        "https://originui.com/r/textarea.json",
-        "https://originui.com/r/label.json",
-        "https://originui.com/r/popover.json",
-        "https://originui.com/r/radio-group.json",
-        "https://originui.com/r/select.json",
-        "https://originui.com/r/sonner.json"
-      ],
       "files": [
         {
           "path": "registry/default/components/comp-542.tsx",
-          "type": "registry:component"
-        },
-        {
-          "path": "registry/default/components/event-calendar/agenda-view.tsx",
-          "type": "registry:component"
-        },
-        {
-          "path": "registry/default/components/event-calendar/calendar-dnd-context.tsx",
-          "type": "registry:component"
-        },
-        {
-          "path": "registry/default/components/event-calendar/constants.ts",
-          "type": "registry:component"
-        },
-        {
-          "path": "registry/default/components/event-calendar/day-view.tsx",
-          "type": "registry:component"
-        },
-        {
-          "path": "registry/default/components/event-calendar/draggable-event.tsx",
-          "type": "registry:component"
-        },
-        {
-          "path": "registry/default/components/event-calendar/droppable-cell.tsx",
-          "type": "registry:component"
-        },
-        {
-          "path": "registry/default/components/event-calendar/event-dialog.tsx",
-          "type": "registry:component"
-        },
-        {
-          "path": "registry/default/components/event-calendar/event-item.tsx",
-          "type": "registry:component"
-        },
-        {
-          "path": "registry/default/components/event-calendar/events-popup.tsx",
-          "type": "registry:component"
-        },
-        {
-          "path": "registry/default/components/event-calendar/event-calendar.tsx",
-          "type": "registry:component"
-        },
-        {
-          "path": "registry/default/components/event-calendar/index.ts",
-          "type": "registry:component"
-        },
-        {
-          "path": "registry/default/components/event-calendar/month-view.tsx",
-          "type": "registry:component"
-        },
-        {
-          "path": "registry/default/components/event-calendar/types.ts",
-          "type": "registry:component"
-        },
-        {
-          "path": "registry/default/components/event-calendar/utils.ts",
-          "type": "registry:component"
-        },
-        {
-          "path": "registry/default/components/event-calendar/week-view.tsx",
-          "type": "registry:component"
-        },
-        {
-          "path": "registry/default/components/event-calendar/hooks/use-current-time-indicator.ts",
-          "type": "registry:component"
-        },
-        {
-          "path": "registry/default/components/event-calendar/hooks/use-event-visibility.ts",
           "type": "registry:component"
         }
       ],
@@ -9760,23 +7895,16 @@
     {
       "name": "comp-543",
       "type": "registry:component",
-      "registryDependencies": [
-        "https://originui.com/r/button.json"
-      ],      
       "files": [
         {
           "path": "registry/default/components/comp-543.tsx",
           "type": "registry:component"
-        },
-        {
-          "path": "registry/default/hooks/use-file-upload.ts",
-          "type": "registry:hook"
-        }        
+        }
       ],
       "meta": {
         "tags": ["upload", "file", "drag and drop", "avatar"]
       }
-    },    
+    },
     {
       "name": "comp-544",
       "type": "registry:component",
@@ -9784,11 +7912,7 @@
         {
           "path": "registry/default/components/comp-544.tsx",
           "type": "registry:component"
-        },
-        {
-          "path": "registry/default/hooks/use-file-upload.ts",
-          "type": "registry:hook"
-        }        
+        }
       ],
       "meta": {
         "tags": ["upload", "file", "drag and drop"],
@@ -9798,18 +7922,11 @@
     {
       "name": "comp-545",
       "type": "registry:component",
-      "registryDependencies": [
-        "https://originui.com/r/button.json"
-      ],
       "files": [
         {
           "path": "registry/default/components/comp-545.tsx",
           "type": "registry:component"
-        },
-        {
-          "path": "registry/default/hooks/use-file-upload.ts",
-          "type": "registry:hook"
-        }        
+        }
       ],
       "meta": {
         "tags": ["upload", "file", "drag and drop"],
@@ -9819,18 +7936,11 @@
     {
       "name": "comp-546",
       "type": "registry:component",
-      "registryDependencies": [
-        "https://originui.com/r/button.json"
-      ],      
       "files": [
         {
           "path": "registry/default/components/comp-546.tsx",
           "type": "registry:component"
-        },
-        {
-          "path": "registry/default/hooks/use-file-upload.ts",
-          "type": "registry:hook"
-        }        
+        }
       ],
       "meta": {
         "tags": ["upload", "file", "drag and drop"],
@@ -9840,18 +7950,11 @@
     {
       "name": "comp-547",
       "type": "registry:component",
-      "registryDependencies": [
-        "https://originui.com/r/button.json"
-      ],      
       "files": [
         {
           "path": "registry/default/components/comp-547.tsx",
           "type": "registry:component"
-        },
-        {
-          "path": "registry/default/hooks/use-file-upload.ts",
-          "type": "registry:hook"
-        }        
+        }
       ],
       "meta": {
         "tags": ["upload", "file", "drag and drop"],
@@ -9861,18 +7964,11 @@
     {
       "name": "comp-548",
       "type": "registry:component",
-      "registryDependencies": [
-        "https://originui.com/r/button.json"
-      ],      
       "files": [
         {
           "path": "registry/default/components/comp-548.tsx",
           "type": "registry:component"
-        },
-        {
-          "path": "registry/default/hooks/use-file-upload.ts",
-          "type": "registry:hook"
-        }        
+        }
       ],
       "meta": {
         "tags": ["upload", "file", "drag and drop"],
@@ -9882,18 +7978,11 @@
     {
       "name": "comp-549",
       "type": "registry:component",
-      "registryDependencies": [
-        "https://originui.com/r/button.json"
-      ],      
       "files": [
         {
           "path": "registry/default/components/comp-549.tsx",
           "type": "registry:component"
-        },
-        {
-          "path": "registry/default/hooks/use-file-upload.ts",
-          "type": "registry:hook"
-        }        
+        }
       ],
       "meta": {
         "tags": ["upload", "file", "drag and drop"],
@@ -9903,18 +7992,11 @@
     {
       "name": "comp-550",
       "type": "registry:component",
-      "registryDependencies": [
-        "https://originui.com/r/button.json"
-      ],      
       "files": [
         {
           "path": "registry/default/components/comp-550.tsx",
           "type": "registry:component"
-        },
-        {
-          "path": "registry/default/hooks/use-file-upload.ts",
-          "type": "registry:hook"
-        }        
+        }
       ],
       "meta": {
         "tags": ["upload", "file", "drag and drop"],
@@ -9924,40 +8006,25 @@
     {
       "name": "comp-551",
       "type": "registry:component",
-      "registryDependencies": [
-        "https://originui.com/r/button.json",
-        "https://originui.com/r/table.json"
-      ],      
       "files": [
         {
           "path": "registry/default/components/comp-551.tsx",
           "type": "registry:component"
-        },
-        {
-          "path": "registry/default/hooks/use-file-upload.ts",
-          "type": "registry:hook"
-        }        
+        }
       ],
       "meta": {
         "tags": ["upload", "file", "drag and drop"],
         "colSpan": 2
       }
-    },   
+    },
     {
       "name": "comp-552",
       "type": "registry:component",
-      "registryDependencies": [
-        "https://originui.com/r/button.json"
-      ],      
       "files": [
         {
           "path": "registry/default/components/comp-552.tsx",
           "type": "registry:component"
-        },
-        {
-          "path": "registry/default/hooks/use-file-upload.ts",
-          "type": "registry:hook"
-        }        
+        }
       ],
       "meta": {
         "tags": ["upload", "file", "drag and drop"],
@@ -9967,18 +8034,11 @@
     {
       "name": "comp-553",
       "type": "registry:component",
-      "registryDependencies": [
-        "https://originui.com/r/button.json"
-      ],      
       "files": [
         {
           "path": "registry/default/components/comp-553.tsx",
           "type": "registry:component"
-        },
-        {
-          "path": "registry/default/hooks/use-file-upload.ts",
-          "type": "registry:hook"
-        }        
+        }
       ],
       "meta": {
         "tags": ["upload", "file", "drag and drop"],


### PR DESCRIPTION
this PR is made to fix - [10+ corrections to be made for registry.json](https://github.com/origin-space/originui/issues/342)

- just via switching as below, there will be no human error, and all errors above are fixed automatically


```diff
{
- "registry:build": "shadcn build"
+ "registry:build": "smart-registry"
}
```

> [!NOTE]
> if we don't wish to make any changes other then package.json, we can UNDO changes made to file registry.json, no code is added to it anyways, only subtracted

---

in future if we need to add a new component, all we need to do is (and nothing else, seriously nothing else) -

- more files? nope, smart-registry adds them for you
- dependencies, registryDeps, devDeps? nope, smart-registry adds them for you

```json
{
  "name": "comp-[number]",
  "type": "registry:component",
  "files": [
    {
      "path": "registry/default/components/comp-[number].tsx",
      "type": "registry:component"
    }
  ],
  "meta": {
    "tags": ["tag1", "tag2", "..."],
    "colSpan": "number (optional)"
  }
}
```

you can always add additional files and deps (human error prone)

if you wish to be shadcn build compatible, won't make any difference during `smart-registry` generation as `smart-registry` is drop-in yet smart replacement to `shadcn build` but still a shadcn compatible registry is generated at `public/r/registry.json` 🔥

---

🔥 bonus - smart-registry also yields `style.json` and `ui.json` (i.e. equivalent to `shadcn add -a`), in our case -

```sh
# add all originui's UI components
npx shadcn add https://originui.com/r/ui.json
```

and voila we have all `registry:ui` components from originui in our existing project

- and if you wish to update cssVars only aka `registry:style`

```sh
# add all cssVars to the stylesheet
npx shadcn add https://originui.com/r/style.json
```

---

previews and tests -

1. site: 

```sh
https://originui-git-infallible-registry-generated-nrjdalals-projects.vercel.app
```

2. auto-generated shadcn compatible registry

```sh
https://originui-git-infallible-registry-generated-nrjdalals-projects.vercel.app/r/registry.json
```

2. tests:

```sh
# update styles in a project
npx shadcn add https://originui-git-infallible-registry-generated-nrjdalals-projects.vercel.app/r/style.json
# add all originui's components in a project
npx shadcn add https://originui-git-infallible-registry-generated-nrjdalals-projects.vercel.app/r/ui.json
```

<img width="800" alt="Image" src="https://github.com/user-attachments/assets/3e1e5bd4-1e3e-4aab-924f-70e1d68519ab" />