### PR TITLE
fix: eslint error fix in `use-file-upload`

### DIFF
--- a/registry/default/hooks/use-file-upload.ts
+++ b/registry/default/hooks/use-file-upload.ts
@@ -260,7 +260,7 @@ export const useFileUpload = (
       }
     },
     [
-      state.files.length,
+      state.files,
       maxFiles,
       multiple,
       maxSize,


### PR DESCRIPTION
i run the linter in this repo, no linting errors found, while using `use-file-upload` in a project, it gives the eslint error: `Warning: React Hook useCallback has a missing dependency: 'state.files'. Either include it or remove the dependency array.`