### PR TITLE
style: Fix responsive styles for event calendar buttons

### DIFF
--- a/registry/default/components/event-calendar/event-calendar.tsx
+++ b/registry/default/components/event-calendar/event-calendar.tsx
@@ -279,7 +279,7 @@ export function EventCalendar({
           <div className="flex items-center gap-1 sm:gap-4">
             <Button
               variant="outline"
-              className="aspect-square max-[479px]:p-0!"
+              className="max-[479px]:aspect-square max-[479px]:p-0!"
               onClick={handleToday}
             >
               <RiCalendarCheckLine
@@ -346,7 +346,8 @@ export function EventCalendar({
               </DropdownMenuContent>
             </DropdownMenu>
             <Button
-              className="aspect-square max-[479px]:p-0!"
+              className="max-[479px]:aspect-square max-[479px]:p-0!"
+              size="sm"
               onClick={() => {
                 setSelectedEvent(null) // Ensure we're creating a new event
                 setIsEventDialogOpen(true)


### PR DESCRIPTION
# Before
<img width="1179" alt="image" src="https://github.com/user-attachments/assets/487e0747-912f-47cf-8794-9fd09fab912e" />

# After
<img width="1171" alt="image" src="https://github.com/user-attachments/assets/ecf00af9-b95c-417f-a4fc-7074f3b70354" />
