### PR TITLE
Fix: Improve search highlight contrast in Tree with Quick Search

### DIFF
--- a/registry/default/ui/tree.tsx
+++ b/registry/default/ui/tree.tsx
@@ -152,7 +152,7 @@ function TreeItemLabel<T = any>({
     <span
       data-slot="tree-item-label"
       className={cn(
-        "in-focus-visible:ring-ring/50 bg-background hover:bg-accent in-data-[selected=true]:bg-accent in-data-[selected=true]:text-accent-foreground in-data-[drag-target=true]:bg-accent flex items-center gap-1 rounded-sm px-2 py-1.5 text-sm transition-colors not-in-data-[folder=true]:ps-7 in-focus-visible:ring-[3px] in-data-[search-match=true]:bg-blue-50! [&_svg]:pointer-events-none [&_svg]:shrink-0",
+        "in-focus-visible:ring-ring/50 bg-background hover:bg-accent in-data-[selected=true]:bg-accent in-data-[selected=true]:text-accent-foreground in-data-[drag-target=true]:bg-accent flex items-center gap-1 rounded-sm px-2 py-1.5 text-sm transition-colors not-in-data-[folder=true]:ps-7 in-focus-visible:ring-[3px] in-data-[search-match=true]:bg-blue-50 in-data-[search-match=true]:dark:bg-gray-800 [&_svg]:pointer-events-none [&_svg]:shrink-0",
         className
       )}
       {...props}


### PR DESCRIPTION
### Description

This PR improves the visual contrast of the highlighted text in the Tree with Quick Search component.

#### Before
- Poor background/foreground contrast
- Hard to identify matched search terms

#### After
- Clear highlight with better background
- Enhanced readability and accessibility
- Tested across different themes (if applicable)

Let me know if any additional changes are needed!

---  
✔️ Fixes: Search result visibility issue  
🎨 Area: UI / Tree Component  
