### PR TITLE
Replace `comp-62` content to match the correct code

### DIFF
--- a/public/r/comp-62.json
+++ b/public/r/comp-62.json
@@ -8,8 +8,8 @@
   ],
   "files": [
     {
-      "path": "registry/default/components/comp-63.tsx",
-      "content": "import { useId } from \"react\"\n\nimport { Label } from \"@/registry/default/ui/label\"\nimport { Textarea } from \"@/registry/default/ui/textarea\"\n\nexport default function Component() {\n  const id = useId()\n  return (\n    <div className=\"[--ring:var(--color-indigo-300)] *:not-first:mt-2 in-[.dark]:[--ring:var(--color-indigo-900)]\">\n      <Label htmlFor={id}>Textarea with colored border and ring</Label>\n      <Textarea id={id} placeholder=\"Leave a comment\" />\n    </div>\n  )\n}\n",
+      "path": "registry/default/components/comp-62.tsx",    
+      "content": "import { useId } from \"react\"\n\nimport { Label } from \"@/registry/default/ui/label\"\nimport { Textarea } from \"@/registry/default/ui/textarea\"\n\nexport default function Component() {\n  const id = useId()\n  return (\n    <div className=\"*:not-first:mt-2\">\n      <div className=\"flex items-center justify-between gap-1\">\n        <Label htmlFor={id} className=\"leading-6\">\n          Textarea with hint\n        </Label>\n        <span className=\"text-muted-foreground text-sm\">Optional</span>\n      </div>\n      <Textarea id={id} placeholder=\"Leave a comment\" />\n    </div>\n  )\n}\n",
       "type": "registry:component"
     }
   ],


### PR DESCRIPTION
This pull request updates the component definition in the registry by replacing the previous implementation of `comp-63.tsx` with a new version as `comp-62.tsx`. The new component introduces a textarea with a hint and an optional label, improving the UI clarity for users.

Component update:

* Replaced the old `comp-63.tsx` implementation with a new `comp-62.tsx` file, featuring a textarea with a hint and an "Optional" label for improved user guidance.